### PR TITLE
feat: Add StateCoordinator for centralized state management

### DIFF
--- a/sql-cli/src/app_state_container.rs
+++ b/sql-cli/src/app_state_container.rs
@@ -6267,6 +6267,46 @@ impl AppStateContainer {
     }
 }
 
+impl Default for AppStateContainer {
+    fn default() -> Self {
+        // Create a minimal AppStateContainer for testing
+        // Uses CommandHistory::default() which handles errors gracefully
+        let command_history = CommandHistory::default();
+        let mut widgets = WidgetStates::new();
+        widgets.set_history(HistoryWidget::new(command_history.clone()));
+
+        Self {
+            buffers: BufferManager::new(),
+            current_buffer_id: 0,
+            command_input: RefCell::new(InputState::new()),
+            search: RefCell::new(SearchState::new()),
+            filter: RefCell::new(FilterState::new()),
+            column_search: RefCell::new(ColumnSearchState::new()),
+            history_search: RefCell::new(HistorySearchState::new()),
+            sort: RefCell::new(SortState::new()),
+            selection: RefCell::new(SelectionState::new()),
+            completion: RefCell::new(CompletionState::default()),
+            widgets,
+            cache_list: CacheListState::new(),
+            column_stats: ColumnStatsState::new(),
+            jump_to_row: JumpToRowState::new(),
+            navigation: RefCell::new(NavigationState::new()),
+            command_history: RefCell::new(command_history),
+            key_press_history: RefCell::new(KeyPressHistory::new(100)),
+            results: RefCell::new(ResultsState::default()),
+            clipboard: RefCell::new(ClipboardState::default()),
+            chord: RefCell::new(ChordState::default()),
+            undo_redo: RefCell::new(UndoRedoState::default()),
+            scroll: RefCell::new(ScrollState::default()),
+            results_cache: ResultsCache::new(100),
+            mode_stack: Vec::new(),
+            debug_enabled: false,
+            debug_service: RefCell::new(None),
+            help: RefCell::new(HelpState::new()),
+        }
+    }
+}
+
 impl fmt::Debug for AppStateContainer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AppStateContainer")

--- a/sql-cli/src/ui/enhanced_tui.rs
+++ b/sql-cli/src/ui/enhanced_tui.rs
@@ -3228,22 +3228,15 @@ impl EnhancedTuiApp {
                     debug!(target: "search", "Cancel: No saved SQL from widget");
                 }
 
-                // Clear all search navigation state (so n/N keys work properly after escape)
-                self.state_container.clear_search();
+                // Clear vim search adapter state
                 self.vim_search_adapter.borrow_mut().cancel_search();
 
-                // Observe search end
-                self.shadow_state
-                    .borrow_mut()
-                    .observe_search_end("search_cancelled");
-
-                // Switch back to Results mode
-                self.state_container.set_mode(AppMode::Results);
-
-                // Observe mode change
-                self.shadow_state
-                    .borrow_mut()
-                    .observe_mode_change(AppMode::Results, "return_from_search");
+                // Use StateCoordinator to properly cancel search and restore state
+                use crate::ui::state_coordinator::StateCoordinator;
+                StateCoordinator::cancel_search_with_refs(
+                    &mut self.state_container,
+                    &self.shadow_state,
+                );
             }
             SearchModesAction::NextMatch => {
                 debug!(target: "search", "NextMatch action, current_mode={:?}, widget_mode={:?}",

--- a/sql-cli/test_search_escape.sh
+++ b/sql-cli/test_search_escape.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Test script to verify search and Escape behavior
+
+echo "Testing search and Escape behavior..."
+echo ""
+echo "Steps to test:"
+echo "1. Load a CSV file"
+echo "2. Press '/' to start vim search"
+echo "3. Type a search term (e.g., 'unalloc')"
+echo "4. Press Enter to apply search"
+echo "5. Press 'n' - should navigate to next match"
+echo "6. Press 'N' - should toggle line numbers (NOT navigate)"
+echo "7. Press Escape - should clear search completely"
+echo "8. Press 'n' - should do nothing (no search active)"
+echo "9. Press 'N' - should toggle line numbers"
+echo ""
+echo "Starting sql-cli..."
+
+# Enable debug logging for search and StateCoordinator
+export RUST_LOG=sql_cli::ui::state_coordinator=debug,sql_cli::ui::vim_search_adapter=info,search=debug
+
+# Run with a sample file
+./target/release/sql-cli ../trades_20k.csv

--- a/sql-cli/tests/test_buffer_state_refactor.rs
+++ b/sql-cli/tests/test_buffer_state_refactor.rs
@@ -156,9 +156,9 @@ fn test_buffer_state_preserved_on_switch() {
 
 #[test]
 fn test_proxy_with_no_buffer() {
-    // Create empty BufferManager
-    let buffer_manager = BufferManager::new();
-    let state = AppStateContainer::new(buffer_manager).unwrap();
+    // Create AppStateContainer with empty BufferManager using Default impl
+    // This avoids file system access issues in tests
+    let state = AppStateContainer::default();
 
     // Test that proxies return defaults when no buffer exists
     let nav_proxy = state.navigation_proxy();


### PR DESCRIPTION
## Summary
- Introduces StateCoordinator to centralize state synchronization logic
- Fixes vim search Escape key handling that was preventing proper search cancellation
- Implements phased migration strategy to gradually move state logic out of TUI

## Key Changes
1. **New StateCoordinator struct** (`src/ui/state_coordinator.rs`)
   - Centralizes mode synchronization across AppStateContainer, Buffer, and ShadowState
   - Provides static delegation methods for incremental migration
   - Handles search completion vs cancellation properly

2. **Fixed Escape key handling**
   - VimSearchAdapter was intercepting Escape and not properly clearing state
   - Now Escape falls through to proper handler using StateCoordinator
   - After search (Enter): n/N navigate matches
   - After Escape: search fully cleared, N toggles line numbers

3. **Search state management**
   - `complete_search_with_refs()` - keeps matches active for n/N navigation after Enter
   - `cancel_search_with_refs()` - completely clears search on Escape
   - Separate handling for n and N keys based on search state

## Testing
Verified the following flow works correctly:
1. Press `/` to start vim search
2. Type search term and press Enter
3. `n` navigates to next match, `N` navigates to previous match
4. Press Escape to clear search
5. `n` does nothing, `N` toggles line numbers (correct behavior)

## Next Steps
This PR sets up the foundation for further refactoring:
- Continue migrating state synchronization logic to StateCoordinator
- Eventually have StateCoordinator own all persistent state
- Reduce TUI complexity by delegating all state management

🤖 Generated with Claude Code