### PR TITLE
feat(readers): add optional json_path arg to READ_JSON

### DIFF
--- a/src/data/stream_loader.rs
+++ b/src/data/stream_loader.rs
@@ -413,6 +413,78 @@ pub fn parse_json_records(content: &str) -> Result<Vec<JsonValue>> {
     Ok(out)
 }
 
+/// Navigate to a sub-value of a JSON document using a dotted path.
+///
+/// This is the shared "find the rows" step used by both the WEB CTE
+/// `JSON_PATH` clause and `READ_JSON(path, json_path)`. It only *locates* a
+/// value; it deliberately does not filter, transform, or pluck scalars — that
+/// is SQL's job (use a WHERE clause / column list once the rows are loaded).
+/// Anything beyond locating the row set is out of scope; pipe through `jq`.
+///
+/// Supports two forms per dotted segment:
+///   - `name`     — descend into an object key
+///   - `name[]`   — descend into `name` (must be an array), then map the
+///                  remainder of the path across every element. A bare `[]`
+///                  projects over the current value when it is already an array.
+///
+/// Example for an Elasticsearch response:
+///   `hits.hits[]._source`
+/// returns an array of `_source` objects, one per hit — i.e. the `_source`
+/// fields become the top-level row shape consumed by the loader.
+///
+/// An empty path (or one that is only dots) returns the value unchanged.
+pub fn navigate_json_path(value: &JsonValue, path: &str) -> Result<JsonValue> {
+    let parts: Vec<&str> = path.split('.').filter(|p| !p.is_empty()).collect();
+    walk_json_path(value, &parts)
+}
+
+fn walk_json_path(value: &JsonValue, parts: &[&str]) -> Result<JsonValue> {
+    let Some((head, tail)) = parts.split_first() else {
+        return Ok(value.clone());
+    };
+
+    // Array projection: `name[]` (or bare `[]`) maps the rest of the path
+    // across each element of an array.
+    if let Some(name) = head.strip_suffix("[]") {
+        let array_val = if name.is_empty() {
+            value
+        } else {
+            value
+                .get(name)
+                .ok_or_else(|| anyhow::anyhow!("Path '{}' not found in JSON", name))?
+        };
+        let arr = array_val.as_array().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Expected array at '{}' for [] projection, got {}",
+                if name.is_empty() { "<root>" } else { name },
+                json_kind(array_val)
+            )
+        })?;
+        let mut projected = Vec::with_capacity(arr.len());
+        for el in arr {
+            projected.push(walk_json_path(el, tail)?);
+        }
+        return Ok(JsonValue::Array(projected));
+    }
+
+    let next = value
+        .get(head)
+        .ok_or_else(|| anyhow::anyhow!("Path '{}' not found in JSON", head))?;
+    walk_json_path(next, tail)
+}
+
+/// Human-readable JSON type name, for error messages.
+fn json_kind(value: &JsonValue) -> &'static str {
+    match value {
+        JsonValue::Null => "null",
+        JsonValue::Bool(_) => "bool",
+        JsonValue::Number(_) => "number",
+        JsonValue::String(_) => "string",
+        JsonValue::Array(_) => "array",
+        JsonValue::Object(_) => "object",
+    }
+}
+
 /// Compute the ordered union of object keys across the first `sample_size`
 /// records. Order of first occurrence is preserved so the column layout is
 /// stable. Non-object records are skipped.
@@ -579,6 +651,76 @@ fn is_null_field(raw_line: &str, field_index: usize, delimiter: char) -> bool {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    // ---- navigate_json_path tests ----
+
+    #[test]
+    fn test_navigate_json_path_descends_object_key() {
+        // The TeamCity-style case: object with a nested array one level down.
+        let doc = serde_json::json!({
+            "count": 2,
+            "project": [{"id": "a"}, {"id": "b"}]
+        });
+        let extracted = navigate_json_path(&doc, "project").unwrap();
+        assert!(extracted.is_array());
+        assert_eq!(extracted.as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_navigate_json_path_nested_descent() {
+        // TeamCity actually wraps as { projects: { project: [...] } }.
+        let doc = serde_json::json!({
+            "projects": {"project": [{"id": "a"}, {"id": "b"}, {"id": "c"}]}
+        });
+        let extracted = navigate_json_path(&doc, "projects.project").unwrap();
+        assert_eq!(extracted.as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_navigate_json_path_array_projection() {
+        // Elasticsearch-style: project _source out of each hit.
+        let doc = serde_json::json!({
+            "hits": {"hits": [
+                {"_source": {"id": 1}},
+                {"_source": {"id": 2}}
+            ]}
+        });
+        let extracted = navigate_json_path(&doc, "hits.hits[]._source").unwrap();
+        let arr = extracted.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[1]["id"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn test_navigate_json_path_bare_projection_over_root_array() {
+        let doc = serde_json::json!([{"v": {"x": 1}}, {"v": {"x": 2}}]);
+        let extracted = navigate_json_path(&doc, "[].v").unwrap();
+        let arr = extracted.as_array().unwrap();
+        assert_eq!(arr[0]["x"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn test_navigate_json_path_empty_path_is_identity() {
+        let doc = serde_json::json!({"a": 1});
+        let extracted = navigate_json_path(&doc, "").unwrap();
+        assert_eq!(extracted, doc);
+    }
+
+    #[test]
+    fn test_navigate_json_path_missing_key_errors() {
+        let doc = serde_json::json!({"a": 1});
+        let err = navigate_json_path(&doc, "b").unwrap_err();
+        assert!(err.to_string().contains("not found"), "{}", err);
+    }
+
+    #[test]
+    fn test_navigate_json_path_projection_on_non_array_errors() {
+        let doc = serde_json::json!({"a": {"not": "an array"}});
+        let err = navigate_json_path(&doc, "a[]").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Expected array"), "{}", msg);
+        assert!(msg.contains("object"), "{}", msg);
+    }
 
     #[test]
     fn test_csv_from_reader() {

--- a/src/sql/generators/file_readers.rs
+++ b/src/sql/generators/file_readers.rs
@@ -1,8 +1,8 @@
 use crate::data::advanced_csv_loader::AdvancedCsvLoader;
 use crate::data::datatable::{DataColumn, DataRow, DataTable, DataType, DataValue};
 use crate::data::stream_loader::{
-    collect_column_names, detect_delimiter_from_path, parse_delimiter_arg as parse_delim_byte,
-    parse_json_records, CsvReadOptions,
+    collect_column_names, detect_delimiter_from_path, navigate_json_path,
+    parse_delimiter_arg as parse_delim_byte, parse_json_records, CsvReadOptions,
 };
 use crate::sql::generators::TableGenerator;
 use anyhow::{anyhow, Result};
@@ -568,13 +568,22 @@ fn json_records_to_table(
     Ok(table)
 }
 
-/// READ_JSON(path) - Read a whole JSON document and emit one row per object.
+/// READ_JSON(path [, json_path]) - Read a whole JSON document and emit one row per object.
 ///
 /// Accepts either a JSON array of objects (`[{...}, {...}]`, possibly
 /// pretty-printed across many lines) or newline-delimited JSON (JSONL); the
 /// format is auto-detected. This is the multi-line counterpart to READ_JSONL,
 /// which requires exactly one object per line. Pass `-` as the path to read
 /// from stdin (shares the same cached-once buffer as the other stdin readers).
+///
+/// The optional `json_path` drills into a nested document to *locate the rows*
+/// before tabularizing — the same dotted/`[]` syntax as the WEB CTE `JSON_PATH`
+/// clause (see [`navigate_json_path`]). This handles the common API shape of an
+/// object wrapping the array you want, e.g. TeamCity's
+/// `{ "projects": { "project": [...] } }` via `READ_JSON('-', 'projects.project')`,
+/// or Elasticsearch's `READ_JSON('-', 'hits.hits[]._source')`. The path only
+/// finds the row set; use a normal SELECT/WHERE to pick columns and filter —
+/// anything more (predicates, scalar plucking) is a job for a `jq` pre-process.
 pub struct ReadJson;
 
 impl TableGenerator for ReadJson {
@@ -589,11 +598,14 @@ impl TableGenerator for ReadJson {
     }
 
     fn generate(&self, args: Vec<DataValue>) -> Result<Arc<DataTable>> {
-        if args.len() != 1 {
-            return Err(anyhow!("READ_JSON expects 1 argument: (path)"));
+        if args.is_empty() || args.len() > 2 {
+            return Err(anyhow!(
+                "READ_JSON expects 1 or 2 arguments: (path [, json_path])"
+            ));
         }
 
         let path = require_string(&args, 0, "READ_JSON")?;
+        let json_path = optional_string(&args, 1);
 
         let content = if path == "-" {
             // Reconstruct the document from the cached stdin lines so other
@@ -612,19 +624,36 @@ impl TableGenerator for ReadJson {
                 .map_err(|e| anyhow!("READ_JSON failed to read '{}': {}", path, e))?
         };
 
-        let records =
-            parse_json_records(&content).map_err(|e| anyhow!("READ_JSON parse error: {}", e))?;
+        let records = match json_path {
+            // No path: keep the auto-detecting array/JSONL fast path.
+            None => {
+                parse_json_records(&content).map_err(|e| anyhow!("READ_JSON parse error: {}", e))?
+            }
+            // Path given: parse the whole document, drill to the row set, then
+            // normalise to a list of records (array -> rows, single object -> 1
+            // row). Non-object records are rejected later by the table builder.
+            Some(path) => {
+                let value: JsonValue = serde_json::from_str(&content)
+                    .map_err(|e| anyhow!("READ_JSON parse error: {}", e))?;
+                let extracted = navigate_json_path(&value, &path)
+                    .map_err(|e| anyhow!("READ_JSON json_path '{}': {}", path, e))?;
+                match extracted {
+                    JsonValue::Array(arr) => arr,
+                    other => vec![other],
+                }
+            }
+        };
 
         let table = json_records_to_table(records, "read_json", "READ_JSON")?;
         Ok(Arc::new(table))
     }
 
     fn description(&self) -> &str {
-        "Read a whole JSON document — a JSON array of objects (possibly pretty-printed) or newline-delimited JSON — and emit one row per object. Pass '-' as path to read from stdin. Unlike READ_JSONL, the input may span multiple lines per record."
+        "Read a whole JSON document — a JSON array of objects (possibly pretty-printed) or newline-delimited JSON — and emit one row per object. Pass '-' as path to read from stdin. Optional second arg is a JSON path (dotted, with '[]' array projection — same as the WEB CTE JSON_PATH) that drills into a nested document to locate the rows, e.g. READ_JSON('-', 'projects.project'). Unlike READ_JSONL, the input may span multiple lines per record."
     }
 
     fn arg_count(&self) -> usize {
-        1
+        2
     }
 }
 
@@ -1322,17 +1351,6 @@ not json at all
     }
 
     #[test]
-    fn test_read_json_rejects_too_many_args() {
-        let err = ReadJson
-            .generate(vec![
-                DataValue::String("a".to_string()),
-                DataValue::String("b".to_string()),
-            ])
-            .unwrap_err();
-        assert!(err.to_string().contains("1 argument"));
-    }
-
-    #[test]
     fn test_read_json_requires_path() {
         assert!(ReadJson.generate(vec![]).is_err());
     }
@@ -1345,5 +1363,99 @@ not json at all
             )])
             .unwrap_err();
         assert!(err.to_string().contains("READ_JSON failed to read"));
+    }
+
+    #[test]
+    fn test_read_json_json_path_drills_into_nested_array() {
+        // TeamCity-style: object wrapping the array we actually want.
+        let f = write_tmp(
+            r#"{
+  "count": 2,
+  "project": [
+    {"id": "a", "name": "Alpha"},
+    {"id": "b", "name": "Beta"}
+  ]
+}"#,
+        );
+        let table = ReadJson
+            .generate(vec![
+                DataValue::String(f.path().to_string_lossy().to_string()),
+                DataValue::String("project".to_string()),
+            ])
+            .unwrap();
+        assert_eq!(table.row_count(), 2);
+        assert_eq!(table.column_count(), 2);
+        let id_col = col_index(&table, "id");
+        assert_eq!(
+            table.get_value(1, id_col).unwrap(),
+            &DataValue::String("b".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_json_json_path_with_array_projection() {
+        // Elasticsearch-style hits.hits[]._source projection.
+        let f = write_tmp(
+            r#"{
+  "hits": {
+    "hits": [
+      {"_source": {"id": 1, "user": "alice"}},
+      {"_source": {"id": 2, "user": "bob"}}
+    ]
+  }
+}"#,
+        );
+        let table = ReadJson
+            .generate(vec![
+                DataValue::String(f.path().to_string_lossy().to_string()),
+                DataValue::String("hits.hits[]._source".to_string()),
+            ])
+            .unwrap();
+        assert_eq!(table.row_count(), 2);
+        let user_col = col_index(&table, "user");
+        assert_eq!(
+            table.get_value(0, user_col).unwrap(),
+            &DataValue::String("alice".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_json_json_path_single_object_becomes_one_row() {
+        let f = write_tmp(r#"{"meta": {"id": 7, "name": "solo"}}"#);
+        let table = ReadJson
+            .generate(vec![
+                DataValue::String(f.path().to_string_lossy().to_string()),
+                DataValue::String("meta".to_string()),
+            ])
+            .unwrap();
+        assert_eq!(table.row_count(), 1);
+        let id_col = col_index(&table, "id");
+        assert_eq!(table.get_value(0, id_col).unwrap(), &DataValue::Integer(7));
+    }
+
+    #[test]
+    fn test_read_json_json_path_missing_key_errors() {
+        let f = write_tmp(r#"{"project": []}"#);
+        let err = ReadJson
+            .generate(vec![
+                DataValue::String(f.path().to_string_lossy().to_string()),
+                DataValue::String("nope".to_string()),
+            ])
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("json_path"), "{}", msg);
+        assert!(msg.contains("not found"), "{}", msg);
+    }
+
+    #[test]
+    fn test_read_json_rejects_three_args() {
+        let err = ReadJson
+            .generate(vec![
+                DataValue::String("a".to_string()),
+                DataValue::String("b".to_string()),
+                DataValue::String("c".to_string()),
+            ])
+            .unwrap_err();
+        assert!(err.to_string().contains("1 or 2 arguments"));
     }
 }

--- a/src/web/http_fetcher.rs
+++ b/src/web/http_fetcher.rs
@@ -10,7 +10,7 @@ use tracing::{debug, info};
 
 use crate::data::datatable::DataTable;
 use crate::data::stream_loader::{
-    load_csv_from_reader_with_opts, load_json_from_reader, CsvReadOptions,
+    load_csv_from_reader_with_opts, load_json_from_reader, navigate_json_path, CsvReadOptions,
 };
 use crate::sql::parser::ast::{DataFormat, HttpMethod, WebCTESpec};
 
@@ -218,8 +218,7 @@ impl WebDataFetcher {
                     .with_context(|| "Failed to parse JSON for path extraction")?;
 
                 // Navigate to the specified path
-                let extracted = self
-                    .navigate_json_path(&json_value, json_path)
+                let extracted = navigate_json_path(&json_value, json_path)
                     .with_context(|| format!("Failed to extract JSON path: {}", json_path))?;
 
                 // Convert extracted value to bytes and parse as table
@@ -449,8 +448,7 @@ impl WebDataFetcher {
             .with_context(|| "Failed to parse JSON for path extraction")?;
 
         // Navigate to the specified path
-        let extracted = self
-            .navigate_json_path(&json_value, json_path)
+        let extracted = navigate_json_path(&json_value, json_path)
             .with_context(|| format!("Failed to extract JSON path: {}", json_path))?;
 
         // If the extracted value is already an array, use it directly
@@ -466,69 +464,6 @@ impl WebDataFetcher {
         // Re-parse the extracted JSON as a DataTable
         let reader = Cursor::new(extracted_bytes);
         load_json_from_reader(reader, "extracted", "web", json_path)
-    }
-
-    /// Navigate to a specific path in JSON structure.
-    ///
-    /// Supports two forms per dotted segment:
-    ///   - `name`     — descend into an object key
-    ///   - `name[]`   — descend into `name` (must be an array), then map the
-    ///                  remainder of the path across every element
-    ///
-    /// Example for an ES response:
-    ///   `JSON_PATH 'hits.hits[]._source'`
-    /// returns an array of `_source` objects, one per hit — i.e. the
-    /// `_source` fields become the top-level row shape consumed by the loader.
-    fn navigate_json_path(
-        &self,
-        value: &serde_json::Value,
-        path: &str,
-    ) -> Result<serde_json::Value> {
-        let parts: Vec<&str> = path.split('.').filter(|p| !p.is_empty()).collect();
-        Self::walk_json_path(value, &parts)
-    }
-
-    fn walk_json_path(value: &serde_json::Value, parts: &[&str]) -> Result<serde_json::Value> {
-        let Some((head, tail)) = parts.split_first() else {
-            return Ok(value.clone());
-        };
-
-        // Array projection: `name[]` (or bare `[]`) maps the rest of the path
-        // across each element of an array.
-        if let Some(name) = head.strip_suffix("[]") {
-            let array_val = if name.is_empty() {
-                value
-            } else {
-                value
-                    .get(name)
-                    .ok_or_else(|| anyhow::anyhow!("Path '{}' not found in JSON", name))?
-            };
-            let arr = array_val.as_array().ok_or_else(|| {
-                let kind = match array_val {
-                    serde_json::Value::Null => "null",
-                    serde_json::Value::Bool(_) => "bool",
-                    serde_json::Value::Number(_) => "number",
-                    serde_json::Value::String(_) => "string",
-                    serde_json::Value::Array(_) => "array",
-                    serde_json::Value::Object(_) => "object",
-                };
-                anyhow::anyhow!(
-                    "Expected array at '{}' for [] projection, got {}",
-                    if name.is_empty() { "<root>" } else { name },
-                    kind
-                )
-            })?;
-            let mut projected = Vec::with_capacity(arr.len());
-            for el in arr {
-                projected.push(Self::walk_json_path(el, tail)?);
-            }
-            return Ok(serde_json::Value::Array(projected));
-        }
-
-        let next = value
-            .get(head)
-            .ok_or_else(|| anyhow::anyhow!("Path '{}' not found in JSON", head))?;
-        Self::walk_json_path(next, tail)
     }
 
     /// Resolve environment variables in values (${VAR_NAME} or $VAR_NAME syntax)


### PR DESCRIPTION
READ_JSON(path [, json_path]) can now drill into a nested document to locate the row set before tabularizing, using the same dotted/[] array projection syntax as the WEB CTE JSON_PATH clause. This handles the common API shape of an object wrapping the array you want, e.g. TeamCity's { "projects": { "project": [...] } } via READ_JSON('-', 'projects.project'), or Elasticsearch's READ_JSON('-', 'hits.hits[]._source').

The navigator (walk_json_path) is lifted out of http_fetcher.rs - where it was a private method - into a shared navigate_json_path() in stream_loader. The WEB CTE now delegates to it, so there is one navigator, one syntax, and one set of tests instead of two divergent copies.

The path only locates the rows; column selection and filtering stay in SQL (SELECT/WHERE). Predicates and scalar plucking remain out of scope - that is a job for a jq pre-process. The no-path call keeps its original auto-detecting array/JSONL fast path unchanged.

Adds 12 tests (7 navigator, 5 READ_JSON json_path).