### PR TITLE
feat: SQL parity harness vs DuckDB + CI regression gate

### DIFF
--- a/.github/workflows/test-complete.yml
+++ b/.github/workflows/test-complete.yml
@@ -180,6 +180,62 @@ jobs:
           examples/expectations/*.json
           **/*.log
 
+  # SQL parity regression gate (differential test vs DuckDB)
+  parity-tests:
+    name: SQL Parity (vs DuckDB)
+    runs-on: ubuntu-latest
+    needs: rust-tests  # Run after Rust tests to ensure binary builds
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'  # harness uses stdlib tomllib (3.11+)
+
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Set up Rust (for building sql-cli)
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Cache cargo build
+      uses: actions/cache@v4
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-parity-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-build-parity-
+          ${{ runner.os }}-cargo-build-
+
+    - name: Build SQL CLI
+      run: cargo build --release
+
+    - name: Install Python dependencies
+      run: |
+        # Only create .venv if the cache step didn't restore one.
+        [ -d .venv ] || uv venv
+        uv pip install duckdb
+
+    - name: Run parity check (sql-cli vs DuckDB)
+      # Fails if any case drifts from its expected bucket: a regressed AGREE, a
+      # silently-closed gap, or a new un-annotated non-AGREE case. See
+      # docs/SQL_PARITY.md for the contract.
+      run: uv run python tests/comparison/runner.py --check
+
+    - name: Upload parity report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: parity-report
+        path: tests/comparison/reports/
+
   # Integration test combining both
   integration-test:
     name: Integration Test (Linux)

--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -9,6 +9,20 @@ and either **fix** divergences or record **why we won't**.
   `tests/comparison/reports/compare_<ref>.md` (the machine's current GAP/DIFFER list).
 - **This file:** the curated, human decisions behind those buckets. The report
   says *what* diverges right now; this file says *what we're doing about it and why*.
+- **CI gate:** `runner.py --check` runs in `.github/workflows/test-complete.yml`
+  (job *SQL Parity*) and fails the build on any drift from the contract below.
+
+### Regression contract
+
+Each corpus case carries an expectation; `--check` fails if reality disagrees:
+
+- a case with `expect = "GAP" | "DIFFER" | ...` must still be in that bucket;
+- a case with **no** `expect` must be `AGREE`.
+
+This means: fixing a gap is a deliberate edit (drop the `expect`, flip the entry
+below to 🟢), and any *regression* of a passing case is caught automatically. So
+as we work through the backlog, the formal comparison — not just the older test
+suites — is what locks the gains in.
 
 Parity is **broad-brush**, not byte-for-byte. We follow SQL-standard / DuckDB
 semantics where reasonable, and consciously diverge where our design

--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -1,0 +1,75 @@
+# SQL Parity — Book of Work
+
+The durable decision log for SQL-engine parity. We differentially test sql-cli
+against a reference engine (**DuckDB** today) and systematically find, document,
+and either **fix** divergences or record **why we won't**.
+
+- **Harness / raw output:** `tests/comparison/` — run
+  `uv run python tests/comparison/runner.py`; it regenerates
+  `tests/comparison/reports/compare_<ref>.md` (the machine's current GAP/DIFFER list).
+- **This file:** the curated, human decisions behind those buckets. The report
+  says *what* diverges right now; this file says *what we're doing about it and why*.
+
+Parity is **broad-brush**, not byte-for-byte. We follow SQL-standard / DuckDB
+semantics where reasonable, and consciously diverge where our design
+([heterogeneous one-shop querying, coercion-first](FEATURE_ROADMAP_2026_Q2.md))
+makes a different choice better.
+
+## Status legend
+
+| Status | Meaning |
+|---|---|
+| 🔴 OPEN | confirmed divergence, not yet addressed |
+| 🟡 IN PROGRESS | being worked |
+| 🟢 FIXED | resolved; corpus case now AGREEs |
+| ⚪ WON'T FIX | intentional divergence — rationale recorded |
+
+Each entry maps to a corpus case (so `expect=` in the TOML and this log stay in
+sync). When an issue is FIXED, its case should flip to `AGREE` and the `expect`
+annotation be removed.
+
+---
+
+## Open issues
+
+### P1 — `SUBSTRING` is 0-indexed; SQL standard is 1-indexed
+- **Status:** 🔴 OPEN
+- **Corpus:** `03_functions.toml :: fn_substring`
+- **Observed:** `SUBSTRING('AAPL', 1, 2)` → sql-cli `'AP'`, DuckDB/standard `'AA'`.
+- **Decision:** **Fix** — make `SUBSTRING` 1-indexed per SQL standard.
+- **Notes:** String-position semantics may be inconsistent elsewhere (e.g. any
+  `INDEXOF`/`CHARINDEX`/`LEFT`/`RIGHT` style helpers). Audit all position-based
+  string functions as part of this fix, not just `SUBSTRING`.
+
+### P2 — `CAST(expr AS type)` not supported
+- **Status:** 🔴 OPEN
+- **Corpus:** `03_functions.toml :: fn_cast_int`
+- **Observed:** Parse error `Expected RightParen, found As`. There is no `CAST`
+  in the parser; the engine relies on evaluation-time **coercion**, and `CONVERT`
+  is unit conversion (3 args), not type casting.
+- **Decision:** **Fix (best-effort within constraints).** Add `CAST(expr AS type)`
+  to the parser and map it onto the existing coercion layer
+  (`src/data/arithmetic_evaluator.rs` / `DataValue`). Support the common target
+  types we can represent: INTEGER/BIGINT, DOUBLE/FLOAT/REAL, VARCHAR/TEXT,
+  BOOLEAN, DATE/TIMESTAMP. Types we cannot faithfully represent are documented
+  as unsupported rather than silently mis-cast.
+- **Notes:** Coercion-first is our design; CAST should be explicit sugar over the
+  same rules so results stay consistent with implicit coercion.
+
+---
+
+## Won't fix (intentional divergences)
+
+_None yet. When we consciously diverge from the reference engine, record it here
+with the rationale so the DIFFER is understood, not mistaken for a bug._
+
+---
+
+## Workflow
+
+1. Add/extend a tier in `tests/comparison/corpus/NN_*.toml` and run the harness.
+2. For each `GAP`/`DIFFER`, add an entry here with a decision.
+3. Annotate the corpus case with `expect = "GAP"` / `"DIFFER"` so the run flags
+   the day the bucket changes.
+4. On fix: implement, confirm the case flips to `AGREE`, drop the `expect`, set
+   the entry to 🟢 FIXED (or move to Won't Fix with rationale).

--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -56,12 +56,67 @@ annotation be removed.
 - **Notes:** Coercion-first is our design; CAST should be explicit sugar over the
   same rules so results stay consistent with implicit coercion.
 
+### P3 — Correlated subqueries do not apply the outer-row correlation
+- **Status:** 🔴 OPEN — **theme / root cause**, covers several corpus cases
+- **Corpus:** `05_subqueries.toml :: in_subquery_correlated` (DIFFER, returns empty),
+  `scalar_subquery_correlated` (GAP, "returned 0 rows"),
+  `scalar_subquery_in_select_correlated` (GAP),
+  `exists_correlated` (GAP), `not_exists_correlated` (GAP).
+- **Observed:** A subquery referencing an outer column (`WHERE x.region = s.region`)
+  does not see the outer row — it evaluates as if the outer reference is empty,
+  so correlated scalar subqueries error ("0 rows"), correlated `IN` returns an
+  empty set, and `EXISTS` / `NOT EXISTS` don't parse at all.
+- **Decision:** **Fix** — central to the column-scoping work. Two parts:
+  1. **Parser:** accept `[NOT] EXISTS (<subquery>)` as a predicate.
+  2. **Executor:** evaluate correlated subqueries per outer row, resolving outer
+     column references through an enclosing scope. This is the same scoping spine
+     that nested-SQL column resolution needs generally.
+- **Notes:** Uncorrelated scalar / `IN` / derived-table subqueries already AGREE;
+  the gap is specifically the outer-row binding. Highest-leverage fix here — one
+  root cause unlocks five cases and the broader nested-scoping goal.
+
+### P4 — Self-join of the base table fails to resolve
+- **Status:** 🔴 OPEN
+- **Corpus:** `04_joins.toml :: self_join_base`
+- **Observed:** `FROM trades a JOIN trades b ...` → "Cannot resolve table 'trades'
+  for JOIN". Joins to **derived tables / CTEs** built from the same source already
+  work (those cases AGREE); only re-referencing the base table by name fails.
+- **Decision:** **Fix** — register the loaded source so it can be referenced more
+  than once (with aliases) in a join.
+
+### P5 — `CROSS JOIN` to a FROM-less subquery has wrong cardinality
+- **Status:** 🔴 OPEN
+- **Corpus:** `04_joins.toml :: cross_join_constant`
+- **Observed:** `trades t CROSS JOIN (SELECT 1 AS k) c` returns 92×92 = 8464 rows
+  instead of 92. A FROM-less subquery (`SELECT 1 AS k`) yields one row per outer
+  row instead of a single constant row.
+- **Decision:** **Fix** — a FROM-less SELECT must produce exactly one row.
+
+### P6 — `INTERSECT` / `EXCEPT` not implemented
+- **Status:** 🔴 OPEN
+- **Corpus:** `06_ctes_setops.toml :: intersect`, `except`
+- **Observed:** "INTERSECT is not yet implemented" / "EXCEPT is not yet implemented".
+  `UNION` and `UNION ALL` already AGREE.
+- **Decision:** **Fix** — implement alongside the existing `UNION` set-op path.
+
 ---
 
-## Won't fix (intentional divergences)
+## Deferred / won't fix (intentional)
 
-_None yet. When we consciously diverge from the reference engine, record it here
-with the rationale so the DIFFER is understood, not mistaken for a bug._
+### D1 — Recursive CTEs (`WITH RECURSIVE`)
+- **Status:** ⚪ DEFERRED (considered, not supported)
+- **Corpus:** `06_ctes_setops.toml :: recursive_cte`
+- **Observed:** Parser rejects the `name(col, ...)` column-list form;
+  `WITH RECURSIVE` is not implemented.
+- **Rationale:** Considered and consciously deferred. It belongs to a larger
+  potential design direction — a script/session **scope** that can hold
+  variables, staged temp tables, and iterative evaluation — which is out of scope
+  for the current "vanilla SQL consistency" effort. Revisit if/when that scope
+  layer is pursued. Not a bug; do not let the corpus case churn — keep `expect = "GAP"`.
+
+_When we consciously diverge from the reference engine on results (rather than
+simply not implementing a feature), record it here with the rationale so the
+DIFFER is understood, not mistaken for a bug._
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,8 @@ packages = ["tests"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+test = [
+    "duckdb>=1.5.4",
+]

--- a/tests/comparison/.gitignore
+++ b/tests/comparison/.gitignore
@@ -1,0 +1,2 @@
+# Generated each run; the curated record lives in docs/SQL_PARITY.md
+reports/

--- a/tests/comparison/README.md
+++ b/tests/comparison/README.md
@@ -1,0 +1,77 @@
+# SQL engine comparison harness
+
+Differential testing of the sql-cli engine against a reference engine
+(**DuckDB** today; SQLite / SQL Server are drop-in via the adapter interface).
+The goal is *broad-brush* parity, not byte-for-byte equality: run the same data
+and the same SQL through both engines, normalize away formatting noise, and see
+where we agree, disagree, or fall short.
+
+## Run
+
+```bash
+uv run python tests/comparison/runner.py            # all tiers
+uv run python tests/comparison/runner.py 01 02      # only tiers 01, 02
+uv run python tests/comparison/runner.py --verbose  # show diff detail for every case
+uv run python tests/comparison/runner.py --ref duckdb
+```
+
+Requires `cargo build --release` (the harness shells out to `target/release/sql-cli`)
+and the `duckdb` test dependency (`uv add --group test duckdb`, already in `pyproject.toml`).
+
+## Buckets
+
+Every case lands in exactly one bucket:
+
+| Bucket | Meaning | What to do |
+|---|---|---|
+| `AGREE` | both run, results match | candidate to promote into the formal regression suite |
+| `DIFFER` | both run, results disagree | semantics bug — investigate |
+| `GAP` | reference runs, sql-cli errors | the backlog to pick off |
+| `OURS_ONLY` | sql-cli runs, reference errors | our extension / library functions |
+| `BOTH_ERR` | neither supports | frontier parity |
+
+Reports are written to `reports/compare_<ref>.{json,md}` — the markdown lists the
+GAP and DIFFER cases as a ready-made backlog.
+
+## Corpus
+
+Queries live in `corpus/NN_<name>.toml`, tiered from vanilla to complex. Each case:
+
+```toml
+[[case]]
+id   = "where_in_subquery"     # unique, stable name
+data = "trades.csv"            # file in ../../data; table name is the file stem
+sql  = "SELECT ... FROM trades WHERE ..."
+expect = "GAP"                 # optional: assert the current bucket; run flags changes
+```
+
+The table name a query references **must** be the data file's stem (matches how
+sql-cli maps a loaded file to a table). Alias every computed column so its name
+lines up with the reference engine — comparison is by column *name*, since
+sql-cli's JSON output sorts keys.
+
+`expect` is optional. When set, the run flags any case whose bucket no longer
+matches — so closing a gap or fixing a DIFFER shows up immediately without
+editing the harness.
+
+## Normalization
+
+Comparison canonicalizes harmless cross-engine differences (see `normalize.py`
+for the authoritative list): NULL == empty string, int/float/numeric-string
+collapse, boolean spelling, date/datetime objects → ISO with trailing
+fractional-second zeros stripped. Row order is ignored unless the query has
+`ORDER BY`. A `DIFFER` therefore means a *real* disagreement, not formatting.
+
+## Adding an engine
+
+Implement `Engine.run(data_file, table, sql) -> EngineResult` in `engines.py`
+and register it in `REFERENCE_ENGINES`. Everything else (corpus, normalization,
+report) is engine-agnostic.
+
+## Roadmap
+
+- More tiers: joins, subqueries, CTEs, recursive CTEs, window functions,
+  correlated subqueries and column scoping (where the interesting gaps live).
+- Promote stable `AGREE` cases into the formal regression suite.
+- Import [sqllogictest](https://www.sqlite.org/sqllogictest/) corpora behind the
+  same adapter interface once function/type coverage is broad enough.

--- a/tests/comparison/README.md
+++ b/tests/comparison/README.md
@@ -13,7 +13,20 @@ uv run python tests/comparison/runner.py            # all tiers
 uv run python tests/comparison/runner.py 01 02      # only tiers 01, 02
 uv run python tests/comparison/runner.py --verbose  # show diff detail for every case
 uv run python tests/comparison/runner.py --ref duckdb
+uv run python tests/comparison/runner.py --check    # CI gate: exit 1 on any drift
 ```
+
+## Regression gate (`--check`)
+
+`--check` enforces the parity contract and exits non-zero on any violation:
+
+- a case with `expect = "GAP"` (etc.) **must** still be in that bucket;
+- a case with **no** `expect` **must** be `AGREE`.
+
+So a regressed `AGREE`, a silently-closed gap, or a new un-annotated non-`AGREE`
+case all fail the check. Closing a gap is a deliberate edit (drop the `expect`
+and log it in `docs/SQL_PARITY.md`); regressions are caught for free. This is the
+form run in CI (`.github/workflows/test-complete.yml`, job *SQL Parity*).
 
 Requires `cargo build --release` (the harness shells out to `target/release/sql-cli`)
 and the `duckdb` test dependency (`uv add --group test duckdb`, already in `pyproject.toml`).

--- a/tests/comparison/corpus/01_select.toml
+++ b/tests/comparison/corpus/01_select.toml
@@ -1,0 +1,63 @@
+# Tier 1 — vanilla SELECT: projection, DISTINCT, aliases, arithmetic, ORDER BY.
+# Computed columns are aliased so column names line up across engines.
+
+[[case]]
+id = "select_star"
+data = "trades.csv"
+sql = "SELECT * FROM trades"
+tier = "01"
+
+[[case]]
+id = "select_columns"
+data = "trades.csv"
+sql = "SELECT symbol, price, volume FROM trades"
+
+[[case]]
+id = "select_alias"
+data = "trades.csv"
+sql = "SELECT symbol AS ticker, price AS px FROM trades"
+
+[[case]]
+id = "select_arithmetic"
+data = "trades.csv"
+sql = "SELECT symbol, price * volume AS notional FROM trades"
+
+[[case]]
+id = "select_constant"
+data = "trades.csv"
+sql = "SELECT symbol, 1 AS one, 'x' AS lit FROM trades"
+
+[[case]]
+id = "distinct_single"
+data = "trades.csv"
+sql = "SELECT DISTINCT symbol FROM trades"
+
+[[case]]
+id = "distinct_multi"
+data = "international_sales.csv"
+sql = "SELECT DISTINCT region, currency FROM international_sales"
+
+[[case]]
+id = "order_by_asc"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades ORDER BY price ASC"
+
+[[case]]
+id = "order_by_desc"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades ORDER BY price DESC"
+
+[[case]]
+id = "order_by_multi"
+data = "international_sales.csv"
+sql = "SELECT region, country, amount FROM international_sales ORDER BY region ASC, amount DESC"
+
+[[case]]
+id = "order_by_limit"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades ORDER BY price DESC LIMIT 5"
+
+[[case]]
+id = "order_by_expr"
+data = "trades.csv"
+sql = "SELECT symbol, price, volume FROM trades ORDER BY price * volume DESC"

--- a/tests/comparison/corpus/02_where.toml
+++ b/tests/comparison/corpus/02_where.toml
@@ -1,0 +1,71 @@
+# Tier 2 — WHERE: comparisons, boolean logic, IN, BETWEEN, LIKE, NULL, subqueries.
+
+[[case]]
+id = "where_numeric_gt"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades WHERE price > 185"
+
+[[case]]
+id = "where_string_eq"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades WHERE symbol = 'AAPL'"
+
+[[case]]
+id = "where_and_or"
+data = "international_sales.csv"
+sql = "SELECT * FROM international_sales WHERE region = 'Europe' AND amount > 1000 OR currency = 'GBP'"
+
+[[case]]
+id = "where_in_list"
+data = "international_sales.csv"
+sql = "SELECT * FROM international_sales WHERE currency IN ('USD', 'EUR')"
+
+[[case]]
+id = "where_not_in"
+data = "international_sales.csv"
+sql = "SELECT * FROM international_sales WHERE currency NOT IN ('USD')"
+
+[[case]]
+id = "where_between"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades WHERE price BETWEEN 180 AND 190"
+
+[[case]]
+id = "where_like_prefix"
+data = "instruments.csv"
+sql = "SELECT instrument_id, name FROM instruments WHERE name LIKE 'A%'"
+
+[[case]]
+id = "where_like_contains"
+data = "instruments.csv"
+sql = "SELECT instrument_id, name FROM instruments WHERE name LIKE '%Stock%'"
+
+[[case]]
+id = "where_is_null"
+data = "instruments.csv"
+sql = "SELECT instrument_id FROM instruments WHERE coupon_rate IS NULL"
+
+[[case]]
+id = "where_is_not_null"
+data = "instruments.csv"
+sql = "SELECT instrument_id FROM instruments WHERE coupon_rate IS NOT NULL"
+
+[[case]]
+id = "where_not_expr"
+data = "trades.csv"
+sql = "SELECT symbol FROM trades WHERE NOT (price > 185)"
+
+[[case]]
+id = "where_arith_predicate"
+data = "trades.csv"
+sql = "SELECT symbol, price, volume FROM trades WHERE price * volume > 200000"
+
+[[case]]
+id = "where_in_subquery"
+data = "international_sales.csv"
+sql = "SELECT region, amount FROM international_sales WHERE amount > (SELECT AVG(amount) FROM international_sales)"
+
+[[case]]
+id = "where_in_subquery_set"
+data = "trades.csv"
+sql = "SELECT symbol FROM trades WHERE symbol IN (SELECT symbol FROM trades WHERE price > 185)"

--- a/tests/comparison/corpus/03_functions.toml
+++ b/tests/comparison/corpus/03_functions.toml
@@ -1,0 +1,76 @@
+# Tier 3 — scalar functions: string, math, conditional, NULL handling.
+# These probe semantic parity (arg order, rounding, CASE) and surface gaps.
+
+[[case]]
+id = "fn_upper"
+data = "trades.csv"
+sql = "SELECT UPPER(symbol) AS u FROM trades"
+
+[[case]]
+id = "fn_lower"
+data = "trades.csv"
+sql = "SELECT LOWER(symbol) AS l FROM trades"
+
+[[case]]
+id = "fn_length"
+data = "instruments.csv"
+sql = "SELECT name, LENGTH(name) AS n FROM instruments"
+
+[[case]]
+id = "fn_substring"
+data = "trades.csv"
+sql = "SELECT SUBSTRING(symbol, 1, 2) AS s FROM trades"
+# sql-cli SUBSTRING is 0-indexed; SQL standard / DuckDB is 1-indexed.
+expect = "DIFFER"
+
+[[case]]
+id = "fn_trim"
+data = "instruments.csv"
+sql = "SELECT TRIM(name) AS t FROM instruments"
+
+[[case]]
+id = "fn_concat"
+data = "international_sales.csv"
+sql = "SELECT region || '-' || country AS combo FROM international_sales"
+
+[[case]]
+id = "fn_abs"
+data = "trades.csv"
+sql = "SELECT ABS(price - 185) AS d FROM trades"
+
+[[case]]
+id = "fn_round"
+data = "trades.csv"
+sql = "SELECT ROUND(price, 0) AS r FROM trades"
+
+[[case]]
+id = "fn_ceil_floor"
+data = "trades.csv"
+sql = "SELECT CEIL(price) AS c, FLOOR(price) AS f FROM trades"
+
+[[case]]
+id = "fn_mod"
+data = "trades.csv"
+sql = "SELECT volume % 100 AS m FROM trades"
+
+[[case]]
+id = "fn_coalesce"
+data = "instruments.csv"
+sql = "SELECT instrument_id, COALESCE(coupon_rate, 0) AS cr FROM instruments"
+
+[[case]]
+id = "fn_case_simple"
+data = "trades.csv"
+sql = "SELECT symbol, CASE WHEN price > 185 THEN 'high' ELSE 'low' END AS tier FROM trades"
+
+[[case]]
+id = "fn_case_searched"
+data = "international_sales.csv"
+sql = "SELECT region, CASE WHEN amount > 2000 THEN 'big' WHEN amount > 1000 THEN 'mid' ELSE 'small' END AS bucket FROM international_sales"
+
+[[case]]
+id = "fn_cast_int"
+data = "trades.csv"
+sql = "SELECT CAST(price AS INTEGER) AS pi FROM trades"
+# Parser does not yet accept CAST(expr AS type).
+expect = "GAP"

--- a/tests/comparison/corpus/04_joins.toml
+++ b/tests/comparison/corpus/04_joins.toml
@@ -1,0 +1,38 @@
+# Tier 4 — joins. The harness loads one source file per case (table = file stem),
+# so joins are expressed within a single source: self-join, and joins to derived
+# tables / CTEs built from that source. Multi-file joins need a harness extension
+# (tracked in README roadmap) and are not covered yet.
+
+[[case]]
+id = "self_join_base"
+data = "trades.csv"
+sql = "SELECT a.symbol AS s, a.price AS hi, b.price AS lo FROM trades a JOIN trades b ON a.symbol = b.symbol AND a.price > b.price"
+# Base table cannot be referenced twice: "Cannot resolve table 'trades' for JOIN".
+expect = "GAP"
+
+[[case]]
+id = "join_derived_table"
+data = "international_sales.csv"
+sql = "SELECT s.region AS region, s.amount AS amount, agg.total AS total FROM international_sales s JOIN (SELECT region, SUM(amount) AS total FROM international_sales GROUP BY region) agg ON s.region = agg.region"
+
+[[case]]
+id = "join_cte"
+data = "international_sales.csv"
+sql = "WITH agg AS (SELECT region, SUM(amount) AS total FROM international_sales GROUP BY region) SELECT s.region AS region, agg.total AS total FROM international_sales s JOIN agg ON s.region = agg.region"
+
+[[case]]
+id = "left_join_derived"
+data = "international_sales.csv"
+sql = "SELECT s.country AS country, agg.total AS total FROM international_sales s LEFT JOIN (SELECT region, SUM(amount) AS total FROM international_sales GROUP BY region) agg ON s.region = agg.region"
+
+[[case]]
+id = "join_with_filter"
+data = "international_sales.csv"
+sql = "SELECT s.country AS country, agg.total AS total FROM international_sales s JOIN (SELECT region, SUM(amount) AS total FROM international_sales GROUP BY region) agg ON s.region = agg.region WHERE agg.total > 5000"
+
+[[case]]
+id = "cross_join_constant"
+data = "trades.csv"
+sql = "SELECT t.symbol AS symbol, c.k AS k FROM trades t CROSS JOIN (SELECT 1 AS k) c"
+# FROM-less subquery yields N rows instead of 1: produces 92x92 instead of 92.
+expect = "DIFFER"

--- a/tests/comparison/corpus/05_subqueries.toml
+++ b/tests/comparison/corpus/05_subqueries.toml
@@ -1,0 +1,52 @@
+# Tier 5 — subqueries: scalar, derived-table, IN, EXISTS, and (the interesting
+# part) correlated forms that exercise column scoping across query levels.
+
+[[case]]
+id = "scalar_subquery_uncorrelated"
+data = "international_sales.csv"
+sql = "SELECT region, amount, (SELECT MAX(amount) FROM international_sales) AS mx FROM international_sales"
+
+[[case]]
+id = "derived_table"
+data = "international_sales.csv"
+sql = "SELECT region, total FROM (SELECT region, SUM(amount) AS total FROM international_sales GROUP BY region) t"
+
+[[case]]
+id = "in_subquery_uncorrelated"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades WHERE price IN (SELECT price FROM trades WHERE price > 185)"
+
+[[case]]
+id = "in_subquery_correlated"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades t WHERE price IN (SELECT price FROM trades x WHERE x.symbol = t.symbol AND x.price > 185)"
+# Correlation not applied: returns empty. See "correlated subqueries" in SQL_PARITY.md.
+expect = "DIFFER"
+
+[[case]]
+id = "scalar_subquery_correlated"
+data = "international_sales.csv"
+sql = "SELECT region, amount FROM international_sales s WHERE amount = (SELECT MAX(amount) FROM international_sales x WHERE x.region = s.region)"
+# Correlation not applied: inner sees 0 rows. See "correlated subqueries" in SQL_PARITY.md.
+expect = "GAP"
+
+[[case]]
+id = "exists_correlated"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades t WHERE EXISTS (SELECT 1 FROM trades x WHERE x.symbol = t.symbol AND x.price > t.price)"
+# EXISTS not parsed. See "correlated subqueries" in SQL_PARITY.md.
+expect = "GAP"
+
+[[case]]
+id = "not_exists_correlated"
+data = "trades.csv"
+sql = "SELECT symbol, price FROM trades t WHERE NOT EXISTS (SELECT 1 FROM trades x WHERE x.symbol = t.symbol AND x.price > t.price)"
+# NOT EXISTS parse error. See "correlated subqueries" in SQL_PARITY.md.
+expect = "GAP"
+
+[[case]]
+id = "scalar_subquery_in_select_correlated"
+data = "international_sales.csv"
+sql = "SELECT region, country, (SELECT SUM(amount) FROM international_sales x WHERE x.region = s.region) AS region_total FROM international_sales s"
+# Correlation not applied in SELECT-list scalar subquery. See SQL_PARITY.md.
+expect = "GAP"

--- a/tests/comparison/corpus/06_ctes_setops.toml
+++ b/tests/comparison/corpus/06_ctes_setops.toml
@@ -1,0 +1,47 @@
+# Tier 6 — CTEs and set operations.
+
+[[case]]
+id = "cte_single"
+data = "international_sales.csv"
+sql = "WITH x AS (SELECT region, amount FROM international_sales) SELECT region, amount FROM x"
+
+[[case]]
+id = "cte_multiple"
+data = "international_sales.csv"
+sql = "WITH a AS (SELECT region, SUM(amount) AS total FROM international_sales GROUP BY region), b AS (SELECT region FROM a WHERE total > 5000) SELECT region FROM b"
+
+[[case]]
+id = "cte_referencing_cte"
+data = "international_sales.csv"
+sql = "WITH base AS (SELECT region, amount FROM international_sales), agg AS (SELECT region, SUM(amount) AS total FROM base GROUP BY region) SELECT region, total FROM agg"
+
+[[case]]
+id = "union"
+data = "trades.csv"
+sql = "SELECT symbol FROM trades WHERE price > 186 UNION SELECT symbol FROM trades WHERE price < 184"
+
+[[case]]
+id = "union_all"
+data = "international_sales.csv"
+sql = "SELECT region FROM international_sales WHERE amount > 2000 UNION ALL SELECT region FROM international_sales WHERE amount < 100"
+
+[[case]]
+id = "intersect"
+data = "international_sales.csv"
+sql = "SELECT region FROM international_sales WHERE amount > 2000 INTERSECT SELECT region FROM international_sales WHERE amount < 1000"
+# "INTERSECT is not yet implemented".
+expect = "GAP"
+
+[[case]]
+id = "except"
+data = "international_sales.csv"
+sql = "SELECT region FROM international_sales EXCEPT SELECT region FROM international_sales WHERE amount > 2000"
+# "EXCEPT is not yet implemented".
+expect = "GAP"
+
+[[case]]
+id = "recursive_cte"
+data = "trades.csv"
+sql = "WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i < 5) SELECT i FROM n"
+# Recursive CTEs are a known, considered, deferred design item (not supported).
+expect = "GAP"

--- a/tests/comparison/engines.py
+++ b/tests/comparison/engines.py
@@ -1,0 +1,105 @@
+"""Engine adapters for the differential SQL comparison harness.
+
+Each adapter exposes the same `run(data_file, table, sql) -> EngineResult`
+interface so a reference engine (DuckDB today, SQLite / SQL Server later) is a
+drop-in. The corpus SQL always refers to its source by the file *stem* as the
+table name (this matches how sql-cli maps a loaded file to a table), so every
+adapter loads `data_file` into a table called `table` before running `sql`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SQL_CLI = PROJECT_ROOT / "target" / "release" / "sql-cli"
+DATA_DIR = PROJECT_ROOT / "data"
+
+
+@dataclass
+class EngineResult:
+    """Outcome of running one query on one engine."""
+
+    ok: bool
+    rows: Optional[list[dict]] = None  # list of {column_name: value}
+    error: Optional[str] = None
+
+
+class Engine:
+    name = "engine"
+
+    def run(self, data_file: str, table: str, sql: str) -> EngineResult:  # pragma: no cover
+        raise NotImplementedError
+
+
+class SqlCliEngine(Engine):
+    """Runs queries through the release sql-cli binary in JSON output mode."""
+
+    name = "sql-cli"
+
+    def __init__(self, binary: Path = SQL_CLI):
+        self.binary = binary
+
+    def run(self, data_file: str, table: str, sql: str) -> EngineResult:
+        path = DATA_DIR / data_file
+        cmd = [str(self.binary), str(path), "-q", sql, "-o", "json"]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            return EngineResult(False, error="timeout (30s)")
+
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout).strip()
+            last = err.splitlines()[-1] if err else f"exit code {proc.returncode}"
+            return EngineResult(False, error=last)
+
+        out = proc.stdout.strip()
+        if not out:
+            return EngineResult(True, rows=[])
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError as exc:
+            return EngineResult(False, error=f"invalid JSON output: {exc}")
+        if isinstance(data, dict):
+            data = [data]
+        if not isinstance(data, list):
+            return EngineResult(False, error=f"unexpected JSON shape: {type(data).__name__}")
+        return EngineResult(True, rows=data)
+
+
+class DuckDBEngine(Engine):
+    """Reference engine: loads the data file in-process and runs the query."""
+
+    name = "duckdb"
+
+    def run(self, data_file: str, table: str, sql: str) -> EngineResult:
+        import duckdb
+
+        path = DATA_DIR / data_file
+        loc = str(path).replace("'", "''")
+        con = duckdb.connect()
+        try:
+            if path.suffix == ".json":
+                con.execute(f'CREATE TABLE "{table}" AS SELECT * FROM read_json_auto(\'{loc}\')')
+            else:
+                con.execute(f'CREATE TABLE "{table}" AS SELECT * FROM read_csv_auto(\'{loc}\', header=true)')
+            cur = con.execute(sql)
+            cols = [d[0] for d in cur.description]
+            rows = [dict(zip(cols, r)) for r in cur.fetchall()]
+            return EngineResult(True, rows=rows)
+        except Exception as exc:  # noqa: BLE001 - any engine error is a result, not a crash
+            msg = str(exc).strip().splitlines()[0]
+            return EngineResult(False, error=msg)
+        finally:
+            con.close()
+
+
+REFERENCE_ENGINES = {
+    "duckdb": DuckDBEngine,
+    # "sqlite": SqliteEngine,   # future
+    # "sqlserver": SqlServerEngine,
+}

--- a/tests/comparison/normalize.py
+++ b/tests/comparison/normalize.py
@@ -1,0 +1,133 @@
+"""Cross-engine result normalization and comparison.
+
+Different SQL engines disagree on harmless surface details (int vs float, NULL
+vs empty string, date objects vs ISO strings, row order). This module canon-
+icalizes both result sets so the comparison surfaces *semantic* differences,
+not formatting noise. The rules are intentionally documented and lenient --
+a "DIFFER" verdict should mean a real disagreement, not a typing quirk.
+
+Normalization rules
+-------------------
+- Column names      : compared case-insensitively, whitespace-trimmed.
+- NULL == ""        : empty strings are treated as NULL (sql-cli loads empty
+                      CSV fields as NULL; DuckDB does the same for typed cols).
+- Numbers           : int/float/Decimal and numeric-looking strings collapse to
+                      float rounded to FLOAT_TOL decimals (so 1, 1.0, "1" match).
+- Booleans          : True/False and "true"/"false" collapse to "true"/"false".
+- Dates / datetimes : date/datetime objects -> ISO; "T" separator normalized to
+                      a space so "2025-01-01T00:00:00" == "2025-01-01 00:00:00".
+- Row order         : ignored (multiset compare) unless the query has ORDER BY.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from collections import Counter
+from decimal import Decimal
+from typing import Optional
+
+FLOAT_TOL = 6
+
+# Fractional seconds in a datetime ("00.123000" -> "00.123", "00.000" -> "00"):
+# engines emit millisecond vs microsecond precision for the same instant.
+_FRAC_SECONDS = re.compile(r"(:\d{2})\.(\d+)")
+
+
+def _strip_frac(m: "re.Match") -> str:
+    frac = m.group(2).rstrip("0")
+    return m.group(1) + ("." + frac if frac else "")
+
+
+def canon_scalar(v):
+    """Reduce a value to a hashable canonical form for cross-engine comparison."""
+    if v is None:
+        return None
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float, Decimal)):
+        return round(float(v), FLOAT_TOL)
+    if isinstance(v, _dt.datetime):
+        return _FRAC_SECONDS.sub(_strip_frac, v.isoformat(sep=" "))
+    if isinstance(v, _dt.date):
+        return v.isoformat()
+    if isinstance(v, _dt.time):
+        return _FRAC_SECONDS.sub(_strip_frac, v.isoformat())
+
+    s = str(v).strip()
+    if s == "":
+        return None
+    low = s.lower()
+    if low in ("true", "false"):
+        return low
+    try:
+        return round(float(s), FLOAT_TOL)
+    except ValueError:
+        pass
+    return _FRAC_SECONDS.sub(_strip_frac, s.replace("T", " "))
+
+
+def canon_row(row: dict) -> dict:
+    return {str(k).strip().lower(): canon_scalar(v) for k, v in row.items()}
+
+
+def _col_set(rows: list[dict]) -> set:
+    cols: set = set()
+    for r in rows:
+        cols.update(r.keys())
+    return cols
+
+
+def _fmt(rows, cols, limit=3) -> str:
+    shown = [dict(zip(cols, r)) for r in rows[:limit]]
+    extra = "" if len(rows) <= limit else f" (+{len(rows) - limit} more)"
+    return "; ".join(str(s) for s in shown) + extra
+
+
+def has_order_by(sql: str) -> bool:
+    return "order by" in sql.lower()
+
+
+def compare(sqlcli_rows: list[dict], ref_rows: list[dict], ordered: bool) -> tuple[bool, Optional[str]]:
+    """Return (matches, diff_message). diff_message is None on a match."""
+    a = [canon_row(r) for r in sqlcli_rows]
+    b = [canon_row(r) for r in ref_rows]
+
+    ca, cb = _col_set(a), _col_set(b)
+    if ca != cb:
+        only_a = sorted(ca - cb)
+        only_b = sorted(cb - ca)
+        parts = []
+        if only_a:
+            parts.append(f"sql-cli-only cols={only_a}")
+        if only_b:
+            parts.append(f"ref-only cols={only_b}")
+        return False, "column mismatch: " + ", ".join(parts) + " (alias computed columns to align)"
+
+    cols = sorted(ca)
+    ta = [tuple(r.get(c) for c in cols) for r in a]
+    tb = [tuple(r.get(c) for c in cols) for r in b]
+
+    if ordered:
+        if ta == tb:
+            return True, None
+        msg = [f"rows: sql-cli={len(ta)} ref={len(tb)} (ordered)"]
+        for i, (x, y) in enumerate(zip(ta, tb)):
+            if x != y:
+                msg.append(f"  first diff at row {i}:")
+                msg.append(f"    sql-cli: {dict(zip(cols, x))}")
+                msg.append(f"    ref:     {dict(zip(cols, y))}")
+                break
+        return False, "\n".join(msg)
+
+    ca_count, cb_count = Counter(ta), Counter(tb)
+    if ca_count == cb_count:
+        return True, None
+    only_a = list((ca_count - cb_count).elements())
+    only_b = list((cb_count - ca_count).elements())
+    msg = [f"rows: sql-cli={len(ta)} ref={len(tb)}"]
+    if only_a:
+        msg.append(f"  only in sql-cli ({len(only_a)}): {_fmt(only_a, cols)}")
+    if only_b:
+        msg.append(f"  only in ref ({len(only_b)}): {_fmt(only_b, cols)}")
+    return False, "\n".join(msg)

--- a/tests/comparison/runner.py
+++ b/tests/comparison/runner.py
@@ -15,10 +15,14 @@ Usage:
     uv run python tests/comparison/runner.py 01 02           # only those tiers
     uv run python tests/comparison/runner.py --verbose       # show diff detail
     uv run python tests/comparison/runner.py --ref duckdb    # pick reference
+    uv run python tests/comparison/runner.py --check         # CI gate (exit 1 on drift)
 
-A case may declare `expect = "gap"` (etc.) in its TOML; the run flags any case
-whose bucket no longer matches its declared expectation, so closing a gap is
-visible without editing the harness.
+Regression contract (enforced by --check, used in CI):
+  - a case with `expect = "GAP"` (etc.) must still be in that bucket;
+  - a case with NO `expect` must be AGREE.
+Any violation fails the check. So a fixed gap, a regressed AGREE, or a new
+un-annotated non-AGREE case all surface immediately. Closing a gap is therefore
+a deliberate edit (drop the `expect`); regressions are caught for free.
 """
 
 from __future__ import annotations
@@ -82,6 +86,7 @@ def bucket(cli_res, ref_res, sql) -> tuple[str, str | None]:
 def main() -> int:
     argv = sys.argv[1:]
     verbose = "--verbose" in argv
+    check = "--check" in argv
     ref_name = "duckdb"
     if "--ref" in argv:
         ref_name = argv[argv.index("--ref") + 1]
@@ -101,7 +106,7 @@ def main() -> int:
     print(f"=== sql-cli vs {ref.name} :: {len(cases)} cases ===\n")
 
     counts: dict[str, int] = {}
-    surprises: list[str] = []
+    violations: list[str] = []
     report_rows = []
 
     for case in cases:
@@ -121,8 +126,9 @@ def main() -> int:
                 print(f"    {C.DIM}{line}{C.NC}")
 
         expect = case.get("expect")
-        if expect and expect.upper() != b:
-            surprises.append(f"{cid}: declared '{expect}' but is '{b}'")
+        expected_bucket = (expect or "AGREE").upper()
+        if b != expected_bucket:
+            violations.append(f"{cid}: expected '{expected_bucket}' but is '{b}'")
 
         report_rows.append(
             {"id": cid, "tier": case["tier"], "file": case["_file"], "sql": sql,
@@ -135,13 +141,25 @@ def main() -> int:
             color, glyph = BUCKET_STYLE[b]
             print(f"  {color}{glyph} {b:9}{C.NC} {counts[b]}")
 
-    if surprises:
-        print(f"\n{C.YELLOW}Expectation changes ({len(surprises)}):{C.NC}")
-        for s in surprises:
-            print(f"  - {s}")
-
     write_reports(ref.name, report_rows, counts)
     print(f"\nReports written to {REPORT_DIR}/")
+
+    if violations:
+        color = C.RED if check else C.YELLOW
+        label = "Contract violations" if check else "Drift from expectations"
+        print(f"\n{color}{label} ({len(violations)}):{C.NC}")
+        for v in violations:
+            print(f"  - {v}")
+        print(
+            f"\n{C.DIM}A case with `expect` must match its bucket; a case with no "
+            f"`expect` must be AGREE.\n  Fixed a gap? drop its `expect`. New gap? "
+            f"add `expect = \"GAP\"` and log it in docs/SQL_PARITY.md.{C.NC}"
+        )
+        if check:
+            return 1
+    elif check:
+        print(f"\n{C.GREEN}Parity contract holds ({len(report_rows)} cases).{C.NC}")
+
     return 0
 
 

--- a/tests/comparison/runner.py
+++ b/tests/comparison/runner.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S uv run python
+"""Differential SQL test harness: sql-cli vs a reference engine.
+
+Runs the same data + SQL through sql-cli and a reference engine (DuckDB by
+default), normalizes both result sets, and buckets each case:
+
+  AGREE      both run, results match        -> certify as regression test
+  DIFFER     both run, results disagree      -> semantics bug to investigate
+  GAP        reference runs, sql-cli errors  -> the backlog to pick off
+  OURS_ONLY  sql-cli runs, reference errors  -> our extension / library funcs
+  BOTH_ERR   neither supports                -> frontier parity
+
+Usage:
+    uv run python tests/comparison/runner.py                 # all tiers
+    uv run python tests/comparison/runner.py 01 02           # only those tiers
+    uv run python tests/comparison/runner.py --verbose       # show diff detail
+    uv run python tests/comparison/runner.py --ref duckdb    # pick reference
+
+A case may declare `expect = "gap"` (etc.) in its TOML; the run flags any case
+whose bucket no longer matches its declared expectation, so closing a gap is
+visible without editing the harness.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+from engines import REFERENCE_ENGINES, SqlCliEngine
+from normalize import compare, has_order_by
+
+CORPUS_DIR = Path(__file__).resolve().parent / "corpus"
+REPORT_DIR = Path(__file__).resolve().parent / "reports"
+
+
+class C:
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[1;33m"
+    BLUE = "\033[0;34m"
+    CYAN = "\033[0;36m"
+    DIM = "\033[2m"
+    NC = "\033[0m"
+
+
+BUCKET_STYLE = {
+    "AGREE": (C.GREEN, "✓"),
+    "DIFFER": (C.YELLOW, "≠"),
+    "GAP": (C.RED, "🚫"),
+    "OURS_ONLY": (C.BLUE, "+"),
+    "BOTH_ERR": (C.DIM, "·"),
+}
+
+
+def load_cases(tiers: list[str]) -> list[dict]:
+    cases = []
+    files = sorted(CORPUS_DIR.glob("*.toml"))
+    for f in files:
+        tier_prefix = f.stem.split("_", 1)[0]
+        if tiers and tier_prefix not in tiers:
+            continue
+        doc = tomllib.loads(f.read_text())
+        for case in doc.get("case", []):
+            case.setdefault("tier", tier_prefix)
+            case["_file"] = f.name
+            cases.append(case)
+    return cases
+
+
+def bucket(cli_res, ref_res, sql) -> tuple[str, str | None]:
+    if cli_res.ok and ref_res.ok:
+        matches, diff = compare(cli_res.rows, ref_res.rows, has_order_by(sql))
+        return ("AGREE", None) if matches else ("DIFFER", diff)
+    if not cli_res.ok and ref_res.ok:
+        return "GAP", cli_res.error
+    if cli_res.ok and not ref_res.ok:
+        return "OURS_ONLY", ref_res.error
+    return "BOTH_ERR", f"sql-cli: {cli_res.error} | ref: {ref_res.error}"
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    verbose = "--verbose" in argv
+    ref_name = "duckdb"
+    if "--ref" in argv:
+        ref_name = argv[argv.index("--ref") + 1]
+    tiers = [a for a in argv if not a.startswith("--") and a != ref_name]
+
+    if ref_name not in REFERENCE_ENGINES:
+        print(f"Unknown reference engine '{ref_name}'. Available: {list(REFERENCE_ENGINES)}")
+        return 2
+
+    cli = SqlCliEngine()
+    if not cli.binary.exists():
+        print(f"{C.RED}ERROR: {cli.binary} not found. Run 'cargo build --release' first.{C.NC}")
+        return 2
+    ref = REFERENCE_ENGINES[ref_name]()
+
+    cases = load_cases(tiers)
+    print(f"=== sql-cli vs {ref.name} :: {len(cases)} cases ===\n")
+
+    counts: dict[str, int] = {}
+    surprises: list[str] = []
+    report_rows = []
+
+    for case in cases:
+        cid = case["id"]
+        data = case["data"]
+        sql = case["sql"]
+        table = Path(data).stem
+        cli_res = cli.run(data, table, sql)
+        ref_res = ref.run(data, table, sql)
+        b, detail = bucket(cli_res, ref_res, sql)
+        counts[b] = counts.get(b, 0) + 1
+
+        color, glyph = BUCKET_STYLE[b]
+        print(f"{color}{glyph} {b:9}{C.NC} [{case['tier']}] {cid}")
+        if detail and (verbose or b in ("DIFFER",)):
+            for line in str(detail).splitlines():
+                print(f"    {C.DIM}{line}{C.NC}")
+
+        expect = case.get("expect")
+        if expect and expect.upper() != b:
+            surprises.append(f"{cid}: declared '{expect}' but is '{b}'")
+
+        report_rows.append(
+            {"id": cid, "tier": case["tier"], "file": case["_file"], "sql": sql,
+             "bucket": b, "detail": detail, "expect": expect}
+        )
+
+    print("\n=== Summary ===")
+    for b in ("AGREE", "DIFFER", "GAP", "OURS_ONLY", "BOTH_ERR"):
+        if b in counts:
+            color, glyph = BUCKET_STYLE[b]
+            print(f"  {color}{glyph} {b:9}{C.NC} {counts[b]}")
+
+    if surprises:
+        print(f"\n{C.YELLOW}Expectation changes ({len(surprises)}):{C.NC}")
+        for s in surprises:
+            print(f"  - {s}")
+
+    write_reports(ref.name, report_rows, counts)
+    print(f"\nReports written to {REPORT_DIR}/")
+    return 0
+
+
+def write_reports(ref_name: str, rows: list[dict], counts: dict[str, int]) -> None:
+    import json
+
+    REPORT_DIR.mkdir(exist_ok=True)
+    (REPORT_DIR / f"compare_{ref_name}.json").write_text(
+        json.dumps({"reference": ref_name, "counts": counts, "cases": rows}, indent=2)
+    )
+
+    lines = [f"# sql-cli vs {ref_name}", "", "| bucket | count |", "|---|---|"]
+    for b in ("AGREE", "DIFFER", "GAP", "OURS_ONLY", "BOTH_ERR"):
+        if b in counts:
+            lines.append(f"| {b} | {counts[b]} |")
+    gaps = [r for r in rows if r["bucket"] == "GAP"]
+    differs = [r for r in rows if r["bucket"] == "DIFFER"]
+    if gaps:
+        lines += ["", "## Gaps (reference runs, sql-cli errors)", ""]
+        for r in gaps:
+            lines.append(f"- **{r['id']}** ({r['tier']}): `{r['sql']}` — {r['detail']}")
+    if differs:
+        lines += ["", "## Differs (both run, results disagree)", ""]
+        for r in differs:
+            first = str(r["detail"]).splitlines()[0] if r["detail"] else ""
+            lines.append(f"- **{r['id']}** ({r['tier']}): `{r['sql']}` — {first}")
+    (REPORT_DIR / f"compare_{ref_name}.md").write_text("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -128,6 +128,48 @@ toml = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/29/9bad86ed7aa812d8c822a27c15c355b6d5423b991feeec86ed18027b6daa/duckdb-1.5.4.tar.gz", hash = "sha256:f9e32f1cdd106793d79d190186bed9e75289d51e68bd9174e47c04bffedeab6f", size = 18046634, upload-time = "2026-06-17T10:48:52.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/ee/69340af74a3aa21838f14c16a0dd3e58461896ccba41f6bc7f0a01536e23/duckdb-1.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ddd9533ce80f9b851bdd6276960a9286166514a9ceca43d5bc2f0d5842c490d", size = 32656177, upload-time = "2026-06-17T10:47:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/9da267ade389d4e7e533ac0c77b3a7041513a66efab93beb84f27627b0b8/duckdb-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360f2542d09759c3739400f8b787e29b43ba0da665c21756216291458bf6fc59", size = 17318966, upload-time = "2026-06-17T10:47:33.688Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/ad73c1a396288e443b18af50819448060b318c1e933305167c1d7f98a507/duckdb-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0cf932055061e544d3fa27cc6c147da25f3f681ee5980157fb55e77d6c2d9c63", size = 15467572, upload-time = "2026-06-17T10:47:36.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/06/2c52ce3b97c3f21111f3c98a2121ed002e33f86488f55098a37825af6d4a/duckdb-1.5.4-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2d58d39f5e65419cdc27e3875cba4a729a3bbf6bf4016aefb4a2a65335a1d42", size = 19344044, upload-time = "2026-06-17T10:47:38.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7d/5c0cc66fb90a1b14474eebb5ab535eacc51cb20b0e45358348b51c07abc9/duckdb-1.5.4-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9a10dc40469b9c0e458625d2a8359461a982c6151bb53ff259fea00c4695ad4", size = 21448215, upload-time = "2026-06-17T10:47:40.617Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/16c3ea201855cdfb7dde52ea3678d0536861cb485ffad46cf345436d658d/duckdb-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:3565550adbf160ef7a2ee3395470570182f11233983ad818bd7d5f9e349f92b2", size = 13132138, upload-time = "2026-06-17T10:47:43.085Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bb/7921dabd50daef3969f14cd8a5a14c24eee337db7914a462f2defa8add92/duckdb-1.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fb41d9cfccb7e44511eeeed263ae98143ca63bdb1ef84631ba637c314efa1b5", size = 32663142, upload-time = "2026-06-17T10:47:45.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/83/2137765eaba6a9aefe3bb9848ddaac7407fe3ba19b292f98b31f3b7ab27f/duckdb-1.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ba7b666bc9c78d6a930ee9f469024149f0c6a23fb7d2c3418aad6774339bec0", size = 17321485, upload-time = "2026-06-17T10:47:47.778Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/a02c1ee43fd7e8cf1fc2e3d377f3dcf9d4a3e58a4549557516e1866ff0da/duckdb-1.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9d9e6817fcbc09d2605a2c8c041ac7824d738d917c35a4d427e977647e1d7944", size = 15470820, upload-time = "2026-06-17T10:47:49.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/48/a243d30223b024bc6057abe472b002cff01e97efefb4d2f0b0dcc5aece0b/duckdb-1.5.4-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02dd9f9a6124069213f13e3a474c208028c472fe1acdae12b38761f954fe4fc6", size = 19341849, upload-time = "2026-06-17T10:47:52.205Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/a5d48de4771e2403a8ef26a20dc7457b1c8f7e398ff0caf9c0cad8805f89/duckdb-1.5.4-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccc7f2694d02b4763fee61021d45e12f7bc5743993686563957df0cef799fbae", size = 21451698, upload-time = "2026-06-17T10:47:54.653Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/8244d7741b4afae67775cf0cb0d4eb9e923a83110907e4801e17fa078480/duckdb-1.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:4c430e788d99b50854209bf2833ba36a45df75e57f86efb477046cd408bbd077", size = 13132643, upload-time = "2026-06-17T10:47:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/57/8169822a37f6dd7d561c567f9007e3cf04bf97bccb619afe90db849c0962/duckdb-1.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:e2dc8340cfb6006025a798c50f40126d6e945a1d2487be94667bb4166556ce7b", size = 13986386, upload-time = "2026-06-17T10:47:59.345Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f2/e2f4b477ae3a3b40e8b5f429832e48edb62ed9da99807cc4902e157e5646/duckdb-1.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:291a9e7502551170af989ff63139a7a49e99d68edbc5ef5017ac27541fe54c65", size = 32708876, upload-time = "2026-06-17T10:48:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/b698d82a5e1e30b6a05748d72045f672994c6b22f4f0f8423523608b991f/duckdb-1.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83e8c089bbb756ca4471d8b05943b80a106058697cf00615e70423106bb783bc", size = 17346125, upload-time = "2026-06-17T10:48:04.035Z" },
+    { url = "https://files.pythonhosted.org/packages/71/75/37e13f39268eaf34864453b3a039c4a1ff0b088d3eae45a4289b41c98c1b/duckdb-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff96d2a342b200e1ec6f1f19986c77f4ac16a49b6112f71c5b763989203a9d60", size = 15488133, upload-time = "2026-06-17T10:48:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/59/2d082af578f689231798245b54562c61416e49049b0bda81a06c56a4b53e/duckdb-1.5.4-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f935ef210ab00bc94bb1e3052697adaa36bb0ce7bdfeda8b0f34e2ff1643870", size = 19367895, upload-time = "2026-06-17T10:48:08.59Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/55c34d2863a76ca824ef8274691e84240b4ff1acde3d231709e82557c240/duckdb-1.5.4-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cda263d8c20addb8d4f95464787cbe0af1144f7ab7e21db3709fb826ee01725", size = 21486499, upload-time = "2026-06-17T10:48:10.963Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/30/ade5952b8182fac86fab43b95ebe3836e66381d0ad64eb1e54bd8207c988/duckdb-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:266c7c909558ce7377f57d082cee408aadebdd9111be017558ca54e44a031037", size = 13147934, upload-time = "2026-06-17T10:48:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/278f0f70e25b9911afe2fd227b9460f2e6d76177f0dcc03f7f1454afefa5/duckdb-1.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:f14e79a006341f29ee5a2692a24dac5114e77533d579c57ec39124adf0135033", size = 13965235, upload-time = "2026-06-17T10:48:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/3fcb34e523a9bad1f0557a6c7691a71ba66c43a05e5be9ee96a9a841ed65/duckdb-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:42a612e67d64450b446eb69695290d460713eef46e0f64467ab9dfe96264ee05", size = 32708366, upload-time = "2026-06-17T10:48:18.084Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fb6f07d54ecf4d0d3c5179a2361fdddfafa14de4fc42696de4632479b703421", size = 17345735, upload-time = "2026-06-17T10:48:20.67Z" },
+    { url = "https://files.pythonhosted.org/packages/93/12/d1b2b344e9699246aada6f9de5156e708fb476e2780e5bff9b5d95fe11d9/duckdb-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f32ad7e0286c1c29ab6c73b29118c86101f8eee46aae54f54d0b50916f542f6", size = 15488568, upload-time = "2026-06-17T10:48:23.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/ac56c6096e3e95da60b2c5dd5a0f0eb5540a80622e2e4f8faab893ec4e96/duckdb-1.5.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:698ec90bd5d5538bd5f6d212a4b61af443d240703cf45f134738535026556ea5", size = 19368184, upload-time = "2026-06-17T10:48:25.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/2ae4c3e157a19d9b4ac1f09a5dea6f93012334cc2db09f1e0c71eb99693d/duckdb-1.5.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136cea7f886b78caf4035485b4b1e766e8b309e999f9e83a966f81ebb8122844", size = 21486523, upload-time = "2026-06-17T10:48:27.817Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/c3d8d21e0d0db8faa81eeeb3a55b9932f5a0a16466cb968dc713a653d701/duckdb-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:bd6777e8ddd74fb603a6d09766bfcff28638189f8aaa61fc0dffd9e9a4baa8e5", size = 13147807, upload-time = "2026-06-17T10:48:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/ddf8d3740e3d28582944f70d84e720b5dc28c10ec22b668a0e0bd965f2f2/duckdb-1.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:73f4878a3012283024a64a1909e440aac12091ef336f671fc142f7e87449ce0c", size = 13965189, upload-time = "2026-06-17T10:48:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/67ac4cbc8e552a1e14c029b5c443d828e68f94d5d913c574f577e1db277e/duckdb-1.5.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4647968629d0677bbcc2416c7aeda8685eb84e4ca15a6dbd4f82a66cfc91a532", size = 32714364, upload-time = "2026-06-17T10:48:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/eb44d983fa56b175f971eea251bde284a36d26cbb93fcb68035061f54078/duckdb-1.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e8fcef301cf68d3951ea1eb8ac4d76cea0a6f6a08f4c78fe4026fc96d217bebc", size = 17349820, upload-time = "2026-06-17T10:48:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b2/b9dc7624b105d414585b8530451c1162c0b4750c0be9be2e497bb47a8a9b/duckdb-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f6f39cd0dc6948dee17fd130aec55114f97a8ef6e1db519b9774087962bc5c8c", size = 15498160, upload-time = "2026-06-17T10:48:40.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/61356444f6a8c62dec3c3d129abfc53f428de1d484093d1bb381db441231/duckdb-1.5.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262f068158beb5943f2c618f4e54b46db8306b959f90dce956f90a89f613673d", size = 19374183, upload-time = "2026-06-17T10:48:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f4/d5d633dd7c5138d8f7c434e6ac2553c831b7fb658494efa8d0bc73df8623/duckdb-1.5.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d2307a76d199077b0055b354e90e857479461a0d875437535dd4833172c8b6d", size = 21487202, upload-time = "2026-06-17T10:48:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/26/5be13bbd5c3421dccfc1ad4ca9da4b97c5a3ddd73f66542092f3167ec52c/duckdb-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:6dcbb81a1276bc48deb4d562bce4f8895e4fc6348750a096e30052345c6d6552", size = 13666989, upload-time = "2026-06-17T10:48:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/4d52f3f9f9703a226b26b80bdae3f6905aeefe5221bf1815fc93ff02ca25/duckdb-1.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:0f8722346024e5d9f02b58bf7b0491a629f97fdc8a04a10e432940f471ee387a", size = 14449863, upload-time = "2026-06-17T10:48:50.18Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -572,6 +614,11 @@ dependencies = [
     { name = "pytest-cov" },
 ]
 
+[package.dev-dependencies]
+test = [
+    { name = "duckdb" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = ">=2.0.0" },
@@ -580,6 +627,9 @@ requires-dist = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
 ]
+
+[package.metadata.requires-dev]
+test = [{ name = "duckdb", specifier = ">=1.5.4" }]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
## What

A **differential test harness** that runs the same data + SQL through sql-cli and a reference engine (**DuckDB** today; SQLite / SQL Server are drop-in via the `Engine` adapter), normalizes cross-engine formatting noise, and buckets each case:

| Bucket | Meaning |
|---|---|
| `AGREE` | both run, results match → certify as regression test |
| `DIFFER` | both run, results disagree → semantics bug |
| `GAP` | reference runs, sql-cli errors → backlog |
| `OURS_ONLY` | sql-cli runs, reference errors → our extension |
| `BOTH_ERR` | neither supports → frontier |

## Layout

- `tests/comparison/` — adapters (`engines.py`), normalizer (`normalize.py`), runner, tiered TOML corpus (tiers 1–6: select / where / functions / joins / subqueries / CTEs+set-ops).
- `docs/SQL_PARITY.md` — the **book of work**: curated fix / won't-fix decisions, keyed to corpus cases via `expect=`.
- CI job **SQL Parity (vs DuckDB)** in `test-complete.yml` runs `runner.py --check`.

## Current state: 62 cases — 50 AGREE / 3 DIFFER / 9 GAP

Backlog logged in `docs/SQL_PARITY.md`:
- **P3** correlated subqueries don't apply outer-row correlation (root cause: IN→empty, scalar errors, EXISTS/NOT EXISTS don't parse) — 5 cases, the column-scoping spine
- **P1** SUBSTRING 0-indexed vs 1-indexed · **P2** no `CAST(expr AS type)` · **P4** self-join of base table · **P5** CROSS JOIN to FROM-less subquery (N×N) · **P6** INTERSECT/EXCEPT unimplemented
- **D1** recursive CTE — deferred by design

## Regression gate

`--check` enforces the contract: a case with `expect` must match its bucket; a case with no `expect` must be `AGREE`. A regressed AGREE, a silently-closed gap, or a new un-annotated non-AGREE case all fail CI. Closing a gap is a deliberate edit (drop the `expect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)