### PR TITLE
feat(sql): add CAST(expr AS type) and TRY_CAST within our type confines

### DIFF
--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -71,19 +71,35 @@ annotation be removed.
   `showcase_deterministic` expectation was re-captured (`'ello '` → `'Hello'`).
 
 ### P2 — `CAST(expr AS type)` not supported
-- **Status:** 🔴 OPEN
-- **Corpus:** `03_functions.toml :: fn_cast_int`
-- **Observed:** Parse error `Expected RightParen, found As`. There is no `CAST`
-  in the parser; the engine relies on evaluation-time **coercion**, and `CONVERT`
-  is unit conversion (3 args), not type casting.
-- **Decision:** **Fix (best-effort within constraints).** Add `CAST(expr AS type)`
-  to the parser and map it onto the existing coercion layer
-  (`src/data/arithmetic_evaluator.rs` / `DataValue`). Support the common target
-  types we can represent: INTEGER/BIGINT, DOUBLE/FLOAT/REAL, VARCHAR/TEXT,
-  BOOLEAN, DATE/TIMESTAMP. Types we cannot faithfully represent are documented
-  as unsupported rather than silently mis-cast.
-- **Notes:** Coercion-first is our design; CAST should be explicit sugar over the
-  same rules so results stay consistent with implicit coercion.
+- **Status:** 🟢 FIXED (2026-07-04)
+- **Corpus:** `03_functions.toml :: fn_cast_int` (now AGREE; `expect` dropped),
+  plus `fn_cast_int_to_double`, `fn_cast_num_to_varchar`,
+  `fn_cast_precision_ignored`, `fn_try_cast_null_on_failure`.
+- **Observed (before):** Parse error `Expected RightParen, found As`. There was no
+  `CAST` in the parser; the engine relied on evaluation-time **coercion**, and
+  `CONVERT` is unit conversion (3 args), not type casting.
+- **Decision:** **Fixed as explicit sugar over the coercion layer.** `CAST` /
+  `TRY_CAST` are **lowered in the parser** into a two-arg function call
+  `CAST(expr, 'TYPE')` (the `AS type` clause is intercepted in
+  `src/sql/parser/expressions/primary.rs`), so they flow through the existing
+  evaluator, WHERE path, and every AST walker without a new `SqlExpression`
+  variant. The cast itself is a registry function
+  (`src/sql/functions/cast.rs`) — matching the "everything goes through the
+  registry" principle.
+- **Type confines (deliberate):** we collapse SQL's char/numeric "zoo" onto the
+  five types `DataValue` stores — INTEGER, DOUBLE (FLOAT/REAL/DECIMAL/NUMERIC),
+  VARCHAR (CHAR/TEXT/STRING/…), BOOLEAN, DATE/TIMESTAMP. A precision/scale spec
+  such as `DECIMAL(10,2)` or `VARCHAR(50)` **parses and is ignored** — no
+  fixed-width CHAR, no decimal scale. Target types we cannot represent (e.g.
+  `BLOB`) are a **query error**, even under `TRY_CAST`.
+- **Semantics matched to DuckDB:** NULL casts to NULL; float→int **rounds**
+  (DuckDB rounds, does not truncate) using **round-half-to-even** so `.5` ties
+  agree (`CAST(2.5 AS INT)=2`); `CAST` errors on an invalid value while
+  `TRY_CAST` yields NULL.
+- **Notes:** Coercion-first is our design; CAST is explicit sugar over the same
+  rules so results stay consistent with implicit coercion. The DuckDB-idiomatic
+  `expr::type` postfix operator is a deliberate follow-up (needs a lexer token);
+  the portable `CAST(... AS ...)` form works in both engines for the corpus.
 
 ### P3 — Correlated subqueries do not apply the outer-row correlation
 - **Status:** 🔴 OPEN — **theme / root cause**, covers several corpus cases

--- a/examples/cast.sql
+++ b/examples/cast.sql
@@ -1,0 +1,82 @@
+-- #! ../data/trades.csv
+-- CAST / TRY_CAST Examples
+-- Demonstrates explicit type casting within sql-cli's type system.
+-- data: data/trades.csv  (columns: symbol, trade_time, price, volume)
+--
+-- sql-cli coerces types implicitly for most operations; CAST(expr AS type) makes
+-- that conversion explicit. We support the handful of types the engine actually
+-- stores: INTEGER, DOUBLE, VARCHAR, BOOLEAN, DATE/TIMESTAMP. The wider "zoo" of
+-- SQL type names (CHAR, TEXT, DECIMAL, BIGINT, ...) is mapped onto these, and any
+-- precision/scale such as DECIMAL(10,2) or VARCHAR(50) is accepted but ignored.
+
+-- === Basic casts on literals ===
+
+-- String -> INTEGER, float -> INTEGER (rounds), integer -> DOUBLE
+SELECT
+    CAST('42' AS INTEGER)   AS str_to_int,
+    CAST(2.9 AS INTEGER)    AS float_to_int,
+    CAST(5 AS DOUBLE)       AS int_to_double;
+GO
+
+-- Float -> INTEGER rounds to nearest (not truncates), with round-half-to-even
+-- on exact .5 ties, matching DuckDB: 2.5 -> 2, 3.5 -> 4.
+SELECT
+    CAST(2.5 AS INTEGER) AS half_down,
+    CAST(3.5 AS INTEGER) AS half_up;
+GO
+
+-- === The character-type "zoo" all collapses to VARCHAR ===
+
+-- VARCHAR, CHAR, TEXT and STRING are equivalent; a size like VARCHAR(50) is
+-- parsed and ignored.
+SELECT
+    CAST(7 AS VARCHAR)      AS as_varchar,
+    CAST(7 AS TEXT)         AS as_text,
+    CAST(7 AS VARCHAR(50))  AS as_varchar_sized;
+GO
+
+-- DECIMAL / NUMERIC map to DOUBLE; the precision/scale spec is ignored
+-- (we cast within our own types rather than honouring width or scale).
+SELECT CAST(price AS DECIMAL(10, 2)) AS price_as_decimal
+FROM trades;
+GO
+
+-- === Casting to BOOLEAN ===
+
+-- Numbers: zero is false, anything non-zero is true.
+-- Strings: true/false, t/f, yes/no, 1/0, on/off (case-insensitive).
+SELECT
+    CAST(0 AS BOOLEAN)        AS zero_is_false,
+    CAST(3 AS BOOLEAN)        AS nonzero_is_true,
+    CAST('true' AS BOOLEAN)   AS str_true,
+    CAST('no' AS BOOLEAN)     AS str_no;
+GO
+
+-- === Casting real columns ===
+
+-- Round each trade price to a whole number.
+SELECT symbol, price, CAST(price AS INTEGER) AS price_rounded
+FROM trades;
+GO
+
+-- CAST participates in expressions like any other value.
+SELECT symbol, CAST(volume AS DOUBLE) / 1000 AS volume_k
+FROM trades;
+GO
+
+-- Use CAST in a WHERE clause to filter on the whole-number price.
+SELECT symbol, price
+FROM trades
+WHERE CAST(price AS INTEGER) > 185;
+GO
+
+-- === TRY_CAST: NULL instead of an error on failure ===
+
+-- CAST('AAPL' AS INTEGER) would raise an error; TRY_CAST yields NULL instead,
+-- so a bad value doesn't abort the whole query.
+SELECT
+    symbol,
+    TRY_CAST(symbol AS INTEGER) AS symbol_as_int,
+    TRY_CAST('123' AS INTEGER)  AS good_value
+FROM trades;
+GO

--- a/src/sql/functions/cast.rs
+++ b/src/sql/functions/cast.rs
@@ -1,0 +1,321 @@
+use anyhow::{anyhow, Result};
+
+use crate::data::datatable::DataValue;
+use crate::sql::functions::{ArgCount, FunctionCategory, FunctionSignature, SqlFunction};
+
+/// The set of target types CAST supports. We deliberately collapse SQL's large
+/// "zoo" of character/numeric types down to the handful of types our engine
+/// actually stores in `DataValue`. This keeps CAST close to DuckDB's observable
+/// behaviour without dragging in fixed-width CHAR, DECIMAL precision, etc.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CastTarget {
+    Integer,
+    Float,
+    Boolean,
+    /// Any character type (VARCHAR/CHAR/TEXT/STRING/…) maps here.
+    Varchar,
+    /// Any temporal type (DATE/DATETIME/TIMESTAMP/…) maps here.
+    DateTime,
+}
+
+impl CastTarget {
+    /// Map a SQL type name (already stripped of any precision/scale) onto one of
+    /// our supported target types. Returns `None` for types we cannot represent.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        let upper = name.trim().to_uppercase();
+        // Collapse "DOUBLE PRECISION" and similar multi-word spellings.
+        let key = upper.split_whitespace().next().unwrap_or("");
+        match key {
+            "INT" | "INTEGER" | "INT1" | "INT2" | "INT4" | "INT8" | "TINYINT" | "SMALLINT"
+            | "BIGINT" | "HUGEINT" | "LONG" | "SHORT" | "SIGNED" | "UINTEGER" | "UBIGINT"
+            | "USMALLINT" | "UTINYINT" => Some(CastTarget::Integer),
+            "DOUBLE" | "FLOAT" | "FLOAT4" | "FLOAT8" | "REAL" | "DECIMAL" | "NUMERIC" | "DEC"
+            | "NUMBER" => Some(CastTarget::Float),
+            "BOOL" | "BOOLEAN" | "LOGICAL" => Some(CastTarget::Boolean),
+            "VARCHAR" | "CHAR" | "CHARACTER" | "TEXT" | "STRING" | "NVARCHAR" | "NCHAR"
+            | "BPCHAR" | "CLOB" => Some(CastTarget::Varchar),
+            "DATE" | "DATETIME" | "TIMESTAMP" | "TIME" => Some(CastTarget::DateTime),
+            _ => None,
+        }
+    }
+}
+
+/// Coerce a value to the requested target type. Errors describe why a value
+/// could not be represented; callers decide whether that error is fatal (CAST)
+/// or should become NULL (TRY_CAST). NULL always casts to NULL.
+pub fn cast_value(value: &DataValue, target: CastTarget) -> Result<DataValue> {
+    if matches!(value, DataValue::Null) {
+        return Ok(DataValue::Null);
+    }
+
+    match target {
+        CastTarget::Integer => cast_to_integer(value),
+        CastTarget::Float => cast_to_float(value),
+        CastTarget::Boolean => cast_to_boolean(value),
+        CastTarget::Varchar => Ok(DataValue::String(value.to_string_optimized())),
+        CastTarget::DateTime => cast_to_datetime(value),
+    }
+}
+
+fn cast_to_integer(value: &DataValue) -> Result<DataValue> {
+    let n = match value {
+        DataValue::Integer(i) => *i,
+        // Numeric-to-int rounds to nearest (matching DuckDB, which rounds rather
+        // than truncates) using round-half-to-even so exact `.5` ties agree with
+        // DuckDB, e.g. CAST(2.5 AS INT) = 2, CAST(3.5 AS INT) = 4.
+        DataValue::Float(f) => f.round_ties_even() as i64,
+        DataValue::Boolean(b) => i64::from(*b),
+        DataValue::String(s) | DataValue::DateTime(s) => parse_integer(s)?,
+        DataValue::InternedString(s) => parse_integer(s)?,
+        other => return Err(anyhow!("cannot cast {:?} to INTEGER", other)),
+    };
+    Ok(DataValue::Integer(n))
+}
+
+fn cast_to_float(value: &DataValue) -> Result<DataValue> {
+    let f = match value {
+        DataValue::Integer(i) => *i as f64,
+        DataValue::Float(f) => *f,
+        DataValue::Boolean(b) => {
+            if *b {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        DataValue::String(s) | DataValue::DateTime(s) => parse_float(s)?,
+        DataValue::InternedString(s) => parse_float(s)?,
+        other => return Err(anyhow!("cannot cast {:?} to DOUBLE", other)),
+    };
+    Ok(DataValue::Float(f))
+}
+
+fn cast_to_boolean(value: &DataValue) -> Result<DataValue> {
+    let b = match value {
+        DataValue::Boolean(b) => *b,
+        DataValue::Integer(i) => *i != 0,
+        DataValue::Float(f) => *f != 0.0,
+        DataValue::String(s) => parse_bool(s)?,
+        DataValue::InternedString(s) => parse_bool(s)?,
+        other => return Err(anyhow!("cannot cast {:?} to BOOLEAN", other)),
+    };
+    Ok(DataValue::Boolean(b))
+}
+
+fn cast_to_datetime(value: &DataValue) -> Result<DataValue> {
+    match value {
+        DataValue::DateTime(s) => Ok(DataValue::DateTime(s.clone())),
+        // We store datetimes as their ISO-8601 string form; a string is taken
+        // at face value rather than re-parsed, to stay within our type confines.
+        DataValue::String(s) => Ok(DataValue::DateTime(s.clone())),
+        DataValue::InternedString(s) => Ok(DataValue::DateTime(s.as_ref().clone())),
+        other => Err(anyhow!("cannot cast {:?} to DATE/TIMESTAMP", other)),
+    }
+}
+
+fn parse_integer(s: &str) -> Result<i64> {
+    let trimmed = s.trim();
+    trimmed
+        .parse::<i64>()
+        .map_err(|_| anyhow!("could not convert string '{}' to INTEGER", trimmed))
+}
+
+fn parse_float(s: &str) -> Result<f64> {
+    let trimmed = s.trim();
+    trimmed
+        .parse::<f64>()
+        .map_err(|_| anyhow!("could not convert string '{}' to DOUBLE", trimmed))
+}
+
+fn parse_bool(s: &str) -> Result<bool> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "true" | "t" | "yes" | "y" | "1" | "on" => Ok(true),
+        "false" | "f" | "no" | "n" | "0" | "off" => Ok(false),
+        other => Err(anyhow!("could not convert string '{}' to BOOLEAN", other)),
+    }
+}
+
+/// SQL `CAST(expr AS type)`.
+///
+/// Parsed into a two-argument function call: `CAST(value, 'TYPE_NAME')`, where
+/// the type name is carried as a string literal by the parser. `try_cast`
+/// distinguishes `CAST` (errors on failure) from `TRY_CAST` (yields NULL).
+pub struct CastFunction {
+    pub try_cast: bool,
+}
+
+impl SqlFunction for CastFunction {
+    fn signature(&self) -> FunctionSignature {
+        if self.try_cast {
+            FunctionSignature {
+                name: "TRY_CAST",
+                category: FunctionCategory::Conversion,
+                arg_count: ArgCount::Fixed(2),
+                description: "Cast a value to a target type, yielding NULL if the cast fails",
+                returns: "Target type",
+                examples: vec![
+                    "SELECT TRY_CAST('abc' AS INTEGER)",
+                    "SELECT TRY_CAST('42' AS INTEGER)",
+                ],
+            }
+        } else {
+            FunctionSignature {
+                name: "CAST",
+                category: FunctionCategory::Conversion,
+                arg_count: ArgCount::Fixed(2),
+                description: "Cast a value to a target type: CAST(expr AS type)",
+                returns: "Target type",
+                examples: vec![
+                    "SELECT CAST('42' AS INTEGER)",
+                    "SELECT CAST(price AS INTEGER) FROM trades",
+                    "SELECT CAST(quantity AS DOUBLE) / 2 FROM trades",
+                ],
+            }
+        }
+    }
+
+    fn evaluate(&self, args: &[DataValue]) -> Result<DataValue> {
+        self.validate_args(args)?;
+
+        let type_name = match &args[1] {
+            DataValue::String(s) => s.as_str(),
+            DataValue::InternedString(s) => s.as_str(),
+            other => {
+                return Err(anyhow!(
+                    "CAST target type must be a type name, got {:?}",
+                    other
+                ))
+            }
+        };
+
+        // An unknown target type is a query error, not a data error — so it
+        // fails even under TRY_CAST.
+        let target = CastTarget::from_name(type_name)
+            .ok_or_else(|| anyhow!("unsupported CAST target type: {}", type_name))?;
+
+        match cast_value(&args[0], target) {
+            Ok(v) => Ok(v),
+            Err(e) if self.try_cast => {
+                let _ = e; // swallowed: TRY_CAST turns cast failures into NULL
+                Ok(DataValue::Null)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cast(value: DataValue, ty: &str) -> Result<DataValue> {
+        let func = CastFunction { try_cast: false };
+        func.evaluate(&[value, DataValue::String(ty.to_string())])
+    }
+
+    fn try_cast(value: DataValue, ty: &str) -> DataValue {
+        let func = CastFunction { try_cast: true };
+        func.evaluate(&[value, DataValue::String(ty.to_string())])
+            .unwrap()
+    }
+
+    #[test]
+    fn string_to_integer() {
+        assert_eq!(
+            cast(DataValue::String("42".into()), "INTEGER").unwrap(),
+            DataValue::Integer(42)
+        );
+    }
+
+    #[test]
+    fn float_to_integer_rounds() {
+        assert_eq!(
+            cast(DataValue::Float(2.9), "INT").unwrap(),
+            DataValue::Integer(3)
+        );
+        assert_eq!(
+            cast(DataValue::Float(-2.9), "BIGINT").unwrap(),
+            DataValue::Integer(-3)
+        );
+    }
+
+    #[test]
+    fn float_to_integer_uses_banker_rounding_like_duckdb() {
+        // Round-half-to-even, matching DuckDB's float->int cast.
+        assert_eq!(
+            cast(DataValue::Float(2.5), "INT").unwrap(),
+            DataValue::Integer(2)
+        );
+        assert_eq!(
+            cast(DataValue::Float(3.5), "INT").unwrap(),
+            DataValue::Integer(4)
+        );
+        assert_eq!(
+            cast(DataValue::Float(-2.5), "INT").unwrap(),
+            DataValue::Integer(-2)
+        );
+    }
+
+    #[test]
+    fn integer_to_double() {
+        assert_eq!(
+            cast(DataValue::Integer(5), "DOUBLE").unwrap(),
+            DataValue::Float(5.0)
+        );
+    }
+
+    #[test]
+    fn char_type_zoo_collapses_to_string() {
+        for ty in [
+            "VARCHAR",
+            "CHAR",
+            "TEXT",
+            "STRING",
+            "VARCHAR(50)".trim_end(),
+        ] {
+            let ty = ty.split('(').next().unwrap();
+            assert_eq!(
+                cast(DataValue::Integer(7), ty).unwrap(),
+                DataValue::String("7".into())
+            );
+        }
+    }
+
+    #[test]
+    fn to_boolean_variants() {
+        assert_eq!(
+            cast(DataValue::Integer(0), "BOOLEAN").unwrap(),
+            DataValue::Boolean(false)
+        );
+        assert_eq!(
+            cast(DataValue::Integer(3), "BOOL").unwrap(),
+            DataValue::Boolean(true)
+        );
+        assert_eq!(
+            cast(DataValue::String("true".into()), "BOOLEAN").unwrap(),
+            DataValue::Boolean(true)
+        );
+    }
+
+    #[test]
+    fn null_casts_to_null() {
+        assert_eq!(cast(DataValue::Null, "INTEGER").unwrap(), DataValue::Null);
+    }
+
+    #[test]
+    fn invalid_cast_errors_but_try_cast_nulls() {
+        assert!(cast(DataValue::String("abc".into()), "INTEGER").is_err());
+        assert_eq!(
+            try_cast(DataValue::String("abc".into()), "INTEGER"),
+            DataValue::Null
+        );
+    }
+
+    #[test]
+    fn unknown_target_type_errors_even_for_try_cast() {
+        let func = CastFunction { try_cast: true };
+        let r = func.evaluate(&[DataValue::Integer(1), DataValue::String("BLOB".to_string())]);
+        assert!(r.is_err());
+    }
+}

--- a/src/sql/functions/mod.rs
+++ b/src/sql/functions/mod.rs
@@ -12,6 +12,7 @@ pub mod bigint;
 pub mod bitwise;
 pub mod bitwise_string;
 pub mod case_convert;
+pub mod cast;
 pub mod chemistry;
 pub mod comparison;
 pub mod constants;
@@ -714,12 +715,16 @@ impl FunctionRegistry {
 
     /// Register conversion functions
     fn register_conversion_functions(&mut self) {
+        use cast::CastFunction;
         use convert::ConvertFunction;
         use roman::{FromRoman, ToRoman};
 
         self.register(Box::new(ConvertFunction));
         self.register(Box::new(ToRoman));
         self.register(Box::new(FromRoman));
+        // CAST(expr AS type) / expr::type, plus the NULL-on-failure TRY_CAST.
+        self.register(Box::new(CastFunction { try_cast: false }));
+        self.register(Box::new(CastFunction { try_cast: true }));
     }
 
     /// Register statistical functions

--- a/src/sql/parser/expressions/primary.rs
+++ b/src/sql/parser/expressions/primary.rs
@@ -137,6 +137,13 @@ where
                     } else {
                         Err("Expected identifier after '.'".to_string())
                     }
+                // CAST(expr AS type) / TRY_CAST(expr AS type) — the `AS type`
+                // form is not a normal argument list, so intercept it here and
+                // lower it into a two-arg function call CAST(expr, 'TYPE').
+                } else if (id_upper == "CAST" || id_upper == "TRY_CAST")
+                    && matches!(ExpressionParser::current_token(parser), Token::LeftParen)
+                {
+                    parse_cast_expression(parser, &id_upper)
                 // Check if this is a function call
                 } else if matches!(ExpressionParser::current_token(parser), Token::LeftParen) {
                     debug!(function = %id_upper, "Parsing function call");
@@ -550,6 +557,74 @@ where
         column: Box::new(column),
         delimiter,
     })
+}
+
+/// Parse a CAST / TRY_CAST expression.
+/// Syntax: `CAST(expr AS type)`.
+/// The current token on entry is the opening `(`. The result is lowered into a
+/// `FunctionCall` so it flows through the existing evaluator and AST machinery:
+/// `CAST(expr, 'TYPE')` where the type name is carried as a string literal.
+fn parse_cast_expression<P>(parser: &mut P, func_name: &str) -> Result<SqlExpression, String>
+where
+    P: ParsePrimary + ExpressionParser + ?Sized,
+{
+    ExpressionParser::advance(parser); // consume (
+
+    let inner = parser.parse_logical_or()?;
+
+    ExpressionParser::consume(parser, Token::As)?;
+
+    let type_name = parse_cast_type_name(parser)?;
+
+    ExpressionParser::consume(parser, Token::RightParen)?;
+
+    let name = if func_name.eq_ignore_ascii_case("TRY_CAST") {
+        "TRY_CAST"
+    } else {
+        "CAST"
+    };
+
+    debug!(target = %type_name, "Parsed CAST expression");
+    Ok(SqlExpression::FunctionCall {
+        name: name.to_string(),
+        args: vec![inner, SqlExpression::StringLiteral(type_name)],
+        distinct: false,
+    })
+}
+
+/// Read a SQL type name for CAST, e.g. `INTEGER`, `VARCHAR`, `DOUBLE`,
+/// `TIMESTAMP`. An optional precision/scale specifier such as `DECIMAL(10, 2)`
+/// or `VARCHAR(50)` is consumed and discarded — we coerce within our own type
+/// confines and do not honour width or scale.
+fn parse_cast_type_name<P>(parser: &mut P) -> Result<String, String>
+where
+    P: ParsePrimary + ExpressionParser + ?Sized,
+{
+    let type_name = match ExpressionParser::current_token(parser) {
+        Token::Identifier(id) => id.clone(),
+        // DATETIME is the one type spelling the lexer reserves as a keyword.
+        Token::DateTime => "DATETIME".to_string(),
+        other => {
+            return Err(format!(
+                "Expected a type name after AS in CAST, got {other:?}"
+            ))
+        }
+    };
+    ExpressionParser::advance(parser);
+
+    // Skip an optional (precision) or (precision, scale) specifier.
+    if matches!(ExpressionParser::current_token(parser), Token::LeftParen) {
+        ExpressionParser::advance(parser); // consume (
+        while !matches!(ExpressionParser::current_token(parser), Token::RightParen) {
+            if matches!(ExpressionParser::current_token(parser), Token::Eof) {
+                return Err("Unterminated type specifier in CAST".to_string());
+            }
+            ExpressionParser::advance(parser);
+        }
+        ExpressionParser::consume(parser, Token::RightParen)?;
+    }
+
+    Ok(type_name)
 }
 
 /// Trait that parsers must implement to use primary expression parsing

--- a/tests/comparison/corpus/03_functions.toml
+++ b/tests/comparison/corpus/03_functions.toml
@@ -72,5 +72,29 @@ sql = "SELECT region, CASE WHEN amount > 2000 THEN 'big' WHEN amount > 1000 THEN
 id = "fn_cast_int"
 data = "trades.csv"
 sql = "SELECT CAST(price AS INTEGER) AS pi FROM trades"
-# Parser does not yet accept CAST(expr AS type).
-expect = "GAP"
+# CAST(expr AS type) is now supported. Float->int rounds to nearest (DuckDB
+# rounds rather than truncates); we use round-half-to-even to match it.
+
+[[case]]
+id = "fn_cast_int_to_double"
+data = "trades.csv"
+sql = "SELECT CAST(volume AS DOUBLE) AS vd FROM trades"
+
+[[case]]
+id = "fn_cast_num_to_varchar"
+data = "trades.csv"
+# Numeric string vs float collapses under normalization, so surface formatting
+# (185.5 vs 185.50) does not matter -- this asserts the value round-trips.
+sql = "SELECT CAST(price AS VARCHAR) AS ps FROM trades"
+
+[[case]]
+id = "fn_cast_precision_ignored"
+data = "trades.csv"
+# A precision/scale spec parses and is ignored; we cast within our own types.
+sql = "SELECT CAST(price AS DECIMAL(10, 2)) AS pd FROM trades"
+
+[[case]]
+id = "fn_try_cast_null_on_failure"
+data = "trades.csv"
+# TRY_CAST of a non-numeric string yields NULL rather than erroring.
+sql = "SELECT symbol, TRY_CAST(symbol AS INTEGER) AS n FROM trades"


### PR DESCRIPTION
Support explicit type casting as sugar over the existing coercion layer, staying within the five types DataValue stores (INTEGER, DOUBLE, VARCHAR, BOOLEAN, DATE/TIMESTAMP). SQL's wider char/numeric "zoo" (CHAR/TEXT/STRING, BIGINT, DECIMAL/NUMERIC, ...) maps onto these, and any precision/scale spec (DECIMAL(10,2), VARCHAR(50)) parses and is ignored.

Implementation avoids a new SqlExpression variant: the parser intercepts the `AS type` clause and lowers CAST/TRY_CAST into a two-arg FunctionCall CAST(expr, 'TYPE'), so it flows through the evaluator, WHERE path, and every AST walker unchanged. The cast itself is a registry function (cast.rs).

Semantics matched to DuckDB (verified against DuckDB 1.5.4 via the parity harness): NULL -> NULL; float -> int rounds (not truncates) using round-half-to-even so .5 ties agree; CAST errors on a bad value while TRY_CAST yields NULL; an unrepresentable target type errors even under TRY_CAST.

- Closes SQL_PARITY.md P2; fn_cast_int flipped GAP -> AGREE, plus 4 new parity cases (int->double, num->varchar, precision-ignored, try_cast-null).
- examples/cast.sql walks users through the forms.
- 9 unit tests in cast.rs.