### PR TITLE
feat(sql): fix CROSS JOIN cardinality and base-table self-join (DuckD…

### DIFF
--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -121,21 +121,27 @@ annotation be removed.
   root cause unlocks five cases and the broader nested-scoping goal.
 
 ### P4 — Self-join of the base table fails to resolve
-- **Status:** 🔴 OPEN
-- **Corpus:** `04_joins.toml :: self_join_base`
-- **Observed:** `FROM trades a JOIN trades b ...` → "Cannot resolve table 'trades'
-  for JOIN". Joins to **derived tables / CTEs** built from the same source already
-  work (those cases AGREE); only re-referencing the base table by name fails.
-- **Decision:** **Fix** — register the loaded source so it can be referenced more
-  than once (with aliases) in a join.
+- **Status:** 🟢 FIXED (2026-07-11)
+- **Corpus:** `04_joins.toml :: self_join_base`, `self_join_aggregate`,
+  `self_left_join_base` (all AGREE)
+- **Observed (was):** `FROM trades a JOIN trades b ...` → "Cannot resolve table
+  'trades' for JOIN". Joins to derived tables / CTEs built from the same source
+  already worked; only re-referencing the base table by name failed.
+- **Fix:** In `query_engine.rs`, when a JOIN target names the main FROM table it
+  now re-references the already-loaded source (`base_table_name` check) and applies
+  the join alias to its qualified columns, mirroring the CTE-in-join path. The
+  right side's columns collide by name with the left, so `HashJoinExecutor` renames
+  them to `<alias>.<col>`, which lets `b.col` resolve in projection.
 
 ### P5 — `CROSS JOIN` to a FROM-less subquery has wrong cardinality
-- **Status:** 🔴 OPEN
-- **Corpus:** `04_joins.toml :: cross_join_constant`
-- **Observed:** `trades t CROSS JOIN (SELECT 1 AS k) c` returns 92×92 = 8464 rows
-  instead of 92. A FROM-less subquery (`SELECT 1 AS k`) yields one row per outer
-  row instead of a single constant row.
-- **Decision:** **Fix** — a FROM-less SELECT must produce exactly one row.
+- **Status:** 🟢 FIXED (2026-07-11)
+- **Corpus:** `04_joins.toml :: cross_join_constant` (now AGREEs)
+- **Observed (was):** `trades t CROSS JOIN (SELECT 1 AS k) c` returned 92×92 = 8464
+  rows instead of 92. A FROM-less subquery (`SELECT 1 AS k`) yielded one row per
+  outer row instead of a single constant row.
+- **Fix:** A FROM-less SELECT now sources from `DataTable::dual()` (a single-row
+  DUAL table) instead of reusing the caller's outer table, in
+  `query_engine.rs`. It produces exactly one row.
 
 ### P6 — `INTERSECT` / `EXCEPT` not implemented
 - **Status:** 🔴 OPEN
@@ -143,6 +149,23 @@ annotation be removed.
 - **Observed:** "INTERSECT is not yet implemented" / "EXCEPT is not yet implemented".
   `UNION` and `UNION ALL` already AGREE.
 - **Decision:** **Fix** — implement alongside the existing `UNION` set-op path.
+
+### P7 — Multi-condition join evaluates extra-condition operands by position
+- **Status:** 🔴 OPEN (found 2026-07-11 while pinning P4)
+- **Corpus:** `04_joins.toml :: join_condition_operand_order` (DIFFER)
+- **Observed:** `... JOIN trades b ON a.symbol = b.symbol AND b.price < a.price`
+  returns rows where `bp > ap`, violating the predicate. The multi-condition
+  nested-loop paths (`nested_loop_join_{inner,left}_multi` in `hash_join.rs`)
+  evaluate each extra condition's `left_expr` against the **left** table and
+  `right_expr` against the **right** table by *syntactic position*, ignoring the
+  actual alias/table each operand belongs to. So `b.price < a.price` (right-table
+  column written first) is silently evaluated as `a.price < b.price`. Writing the
+  same predicate left-table-first (`a.price > b.price`) AGREEs. Affects INNER and
+  LEFT joins.
+- **Decision:** **Fix** — resolve each operand's owning table (by alias qualifier)
+  and evaluate against that table, applying the operator as written. Needs the left
+  alias threaded into the join executor (currently only the right/join alias is
+  passed). Silent wrong answer → high priority.
 
 ---
 

--- a/src/data/query_engine.rs
+++ b/src/data/query_engine.rs
@@ -1373,8 +1373,11 @@ impl QueryEngine {
                             table.clone()
                         }
                     } else {
-                        // No FROM clause - use the provided table
-                        table.clone()
+                        // No FROM clause (e.g. `SELECT 1 AS k`) must yield exactly one
+                        // row, independent of any outer/source table. Reusing the caller's
+                        // `table` here made a FROM-less subquery emit one row per outer row,
+                        // which exploded `CROSS JOIN (SELECT 1 AS k)` cardinality (P5).
+                        Arc::new(DataTable::dual())
                     }
                 }
             }
@@ -1398,6 +1401,16 @@ impl QueryEngine {
             plan.set_rows_in(source_table.row_count());
 
             let join_executor = HashJoinExecutor::new(self.case_insensitive);
+
+            // Name of the main FROM table, so a plain base table can be joined to
+            // itself (P4: `FROM trades a JOIN trades b ...`). Derived tables / CTEs
+            // in the FROM don't have a re-referenceable base name and are skipped.
+            #[allow(deprecated)]
+            let base_table_name = match statement.from_source {
+                Some(TableSource::Table(ref n)) => Some(n.clone()),
+                _ => statement.from_table.clone(),
+            };
+
             let mut current_table = source_table;
 
             for (idx, join_clause) in statement.joins.iter().enumerate() {
@@ -1438,6 +1451,35 @@ impl QueryEngine {
                                 }
                             }
 
+                            Arc::new(materialized)
+                        } else if base_table_name.as_deref().is_some_and(|base| {
+                            if self.case_insensitive {
+                                base.eq_ignore_ascii_case(name)
+                            } else {
+                                base == name
+                            }
+                        }) {
+                            // Self-join of the base table (P4): re-reference the
+                            // already-loaded source. The right side's columns collide
+                            // by name with the left, so HashJoinExecutor renames them
+                            // to `<alias>.<col>` using join_clause.alias; we also rewrite
+                            // qualified names here so `b.col` resolves in projection.
+                            let mut materialized = (*table).clone();
+                            if let Some(ref alias) = join_clause.alias {
+                                for column in materialized.columns_mut() {
+                                    if let Some(ref qualified_name) = column.qualified_name {
+                                        if qualified_name.starts_with(&format!("{}.", name)) {
+                                            column.qualified_name = Some(qualified_name.replace(
+                                                &format!("{}.", name),
+                                                &format!("{}.", alias),
+                                            ));
+                                        }
+                                    }
+                                    if column.source_table.as_ref() == Some(name) {
+                                        column.source_table = Some(alias.clone());
+                                    }
+                                }
+                            }
                             Arc::new(materialized)
                         } else {
                             // For now, we need the actual table data

--- a/tests/comparison/corpus/04_joins.toml
+++ b/tests/comparison/corpus/04_joins.toml
@@ -7,8 +7,31 @@
 id = "self_join_base"
 data = "trades.csv"
 sql = "SELECT a.symbol AS s, a.price AS hi, b.price AS lo FROM trades a JOIN trades b ON a.symbol = b.symbol AND a.price > b.price"
-# Base table cannot be referenced twice: "Cannot resolve table 'trades' for JOIN".
-expect = "GAP"
+# FIXED (P4): the base table can now be re-referenced with aliases in a join.
+
+[[case]]
+id = "self_join_aggregate"
+data = "trades.csv"
+sql = "SELECT a.symbol AS symbol, COUNT(*) AS pairs FROM trades a JOIN trades b ON a.symbol = b.symbol GROUP BY a.symbol ORDER BY a.symbol"
+# Pins P4: base self-join feeding a GROUP BY aggregate.
+
+[[case]]
+id = "self_left_join_base"
+data = "trades.csv"
+sql = "SELECT a.symbol AS s, a.price AS ap, b.price AS bp FROM trades a LEFT JOIN trades b ON a.symbol = b.symbol AND a.price > b.price"
+# Pins P4: LEFT self-join of the base table (unmatched left rows keep NULL bp).
+# Written left-table-first to avoid the separate operand-orientation bug (P7).
+
+[[case]]
+id = "join_condition_operand_order"
+data = "trades.csv"
+sql = "SELECT a.price AS ap, b.price AS bp FROM trades a JOIN trades b ON a.symbol = b.symbol AND b.price < a.price"
+# P7 (NEW GAP): multi-condition nested-loop joins evaluate an extra condition's
+# operands by syntactic position (left_expr->left table, right_expr->right table),
+# ignoring the actual alias. `b.price < a.price` (right-table column first) is thus
+# evaluated as `a.price < b.price`, returning rows that violate the predicate.
+# Same query written `a.price > b.price` AGREEs. Affects INNER and LEFT paths.
+expect = "DIFFER"
 
 [[case]]
 id = "join_derived_table"
@@ -34,5 +57,17 @@ sql = "SELECT s.country AS country, agg.total AS total FROM international_sales 
 id = "cross_join_constant"
 data = "trades.csv"
 sql = "SELECT t.symbol AS symbol, c.k AS k FROM trades t CROSS JOIN (SELECT 1 AS k) c"
-# FROM-less subquery yields N rows instead of 1: produces 92x92 instead of 92.
-expect = "DIFFER"
+# FIXED (P5): FROM-less subquery now yields exactly one row via DUAL, so this
+# CROSS JOIN produces 92 rows and AGREEs with DuckDB.
+
+[[case]]
+id = "cross_join_constant_multicol"
+data = "trades.csv"
+sql = "SELECT t.symbol AS symbol, c.a AS a, c.b AS b FROM trades t CROSS JOIN (SELECT 1 AS a, 2 AS b) c"
+# Pins P5 for a multi-column FROM-less subquery: still exactly one constant row.
+
+[[case]]
+id = "from_less_derived_main"
+data = "trades.csv"
+sql = "SELECT x.k AS k, x.n AS n FROM (SELECT 1 AS k, 2 AS n) x"
+# Pins P5 for a FROM-less subquery used directly as the main FROM: one row.


### PR DESCRIPTION
…B parity)

Two DuckDB-parity join gaps, verified against DuckDB 1.5.4 via the comparison harness (tests/comparison/runner.py):

P5 — CROSS JOIN to a FROM-less subquery had wrong cardinality. A FROM-less SELECT (e.g. `SELECT 1 AS k`) reused the caller's outer table as its source, so `CROSS JOIN (SELECT 1)` emitted one row per outer row (92 -> 8464). It now sources from DataTable::dual() and yields exactly one row.

P4 — self-join of the base table failed to resolve ("Cannot resolve table 'trades' for JOIN"). The join loop now recognises when a JOIN target names the main FROM table and re-references the loaded source with its alias applied, mirroring the existing CTE-in-join path. Colliding right-side columns are renamed to `<alias>.<col>` by HashJoinExecutor, so projection resolves.

Corpus: cross_join_constant + 2 new pins now AGREE; self_join_base + self_join_aggregate + self_left_join_base AGREE. Also adds a tracked DIFFER case (join_condition_operand_order) documenting P7 — multi-condition nested-loop joins bind an extra condition's operands to left/right by syntactic position, so `b.price < a.price` is silently evaluated as `a.price < b.price`. See docs/SQL_PARITY.md P4/P5 (FIXED) and P7 (open).