### PR TITLE
fix(joins): route multi-condition ON operands by alias, not position …

### DIFF
--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -151,21 +151,50 @@ annotation be removed.
 - **Decision:** **Fix** — implement alongside the existing `UNION` set-op path.
 
 ### P7 — Multi-condition join evaluates extra-condition operands by position
-- **Status:** 🔴 OPEN (found 2026-07-11 while pinning P4)
-- **Corpus:** `04_joins.toml :: join_condition_operand_order` (DIFFER)
-- **Observed:** `... JOIN trades b ON a.symbol = b.symbol AND b.price < a.price`
-  returns rows where `bp > ap`, violating the predicate. The multi-condition
+- **Status:** 🟢 FIXED (2026-07-12)
+- **Corpus:** `04_joins.toml :: join_condition_operand_order` (now AGREEs)
+- **Observed (was):** `... JOIN trades b ON a.symbol = b.symbol AND b.price < a.price`
+  returned rows where `bp > ap`, violating the predicate. The multi-condition
   nested-loop paths (`nested_loop_join_{inner,left}_multi` in `hash_join.rs`)
-  evaluate each extra condition's `left_expr` against the **left** table and
+  evaluated each extra condition's `left_expr` against the **left** table and
   `right_expr` against the **right** table by *syntactic position*, ignoring the
   actual alias/table each operand belongs to. So `b.price < a.price` (right-table
-  column written first) is silently evaluated as `a.price < b.price`. Writing the
-  same predicate left-table-first (`a.price > b.price`) AGREEs. Affects INNER and
+  column written first) was silently evaluated as `a.price < b.price`. Writing the
+  same predicate left-table-first (`a.price > b.price`) AGREEd. Affected INNER and
   LEFT joins.
-- **Decision:** **Fix** — resolve each operand's owning table (by alias qualifier)
-  and evaluate against that table, applying the operator as written. Needs the left
-  alias threaded into the join executor (currently only the right/join alias is
-  passed). Silent wrong answer → high priority.
+- **Fix:** Each ON operand is now routed to its owning table by *alias qualifier*
+  rather than syntactic position, in `hash_join.rs`. `operand_uses_right` decides
+  the side: an operand whose prefix equals the join alias belongs to the joined
+  table, any other prefix belongs to the opposite table, and unqualified operands
+  fall back to the old positional default. A `join_alias_is_right` flag threaded
+  into `nested_loop_join_{inner,left}_multi` keeps this correct for the swapped
+  RIGHT-join path (where the join-alias columns live in the `left_table` arg).
+  This is orientation-independent and needs no separate left-alias plumbing: the
+  left/current table accumulates every non-join alias, so "prefix != join alias →
+  left table" holds for chained joins too. The operator is then applied between the
+  two operands exactly as written.
+- **Regression test:** `tests/join_operand_order_tests.rs` pins the self-consistency
+  property (operand order can't change the result) for INNER and LEFT in plain
+  `cargo test`, independent of the DuckDB corpus.
+
+### P8 — Multi-condition RIGHT JOIN mislabels columns and NULLs the wrong side
+- **Status:** 🔴 OPEN (found 2026-07-12 while verifying P7)
+- **Corpus:** `04_joins.toml :: right_join_multi_condition` (DIFFER)
+- **Observed:** `... a RIGHT JOIN trades b ON a.symbol = b.symbol AND a.price < b.price`
+  returns the right *number* of rows but wrong content: the outer (`a`) columns'
+  values surface under `b`'s alias and vice-versa, and NULLs are emitted for the
+  wrong side (the `b` columns instead of the unmatched `a` columns). The RIGHT path
+  reuses `nested_loop_join_left_multi` with the tables swapped but passes the join
+  alias unchanged, so result-column aliasing and the outer-side NULL emission are
+  applied to the swapped-in table. This is **separate from P7** — the P7 operand
+  routing is orientation-correct here; the defect is in RIGHT-join column assembly.
+- **Scope note:** Single-condition RIGHT joins (the hash path) AGREE, so this is
+  confined to the multi-condition nested-loop RIGHT path. Not part of the P7 fix;
+  logged as a follow-up rather than expanded into this change.
+- **Decision:** **Fix** (candidate) — when swapping tables for RIGHT, also swap the
+  alias/outer-side bookkeeping so result columns and NULLs track the physical
+  tables. Silent wrong answer, but narrower blast radius than P7 (RIGHT + multi
+  condition only). Pinned as DIFFER meanwhile.
 
 ---
 

--- a/src/data/hash_join.rs
+++ b/src/data/hash_join.rs
@@ -221,6 +221,7 @@ impl HashJoinExecutor {
                         right_table,
                         &join_clause.condition.conditions,
                         &join_clause.alias,
+                        true, // join-alias table is the `right_table` argument
                     )
                 }
             }
@@ -252,6 +253,7 @@ impl HashJoinExecutor {
                         right_table,
                         &join_clause.condition.conditions,
                         &join_clause.alias,
+                        true, // join-alias table is the `right_table` argument
                     )
                 }
             }
@@ -284,12 +286,15 @@ impl HashJoinExecutor {
                     )
                 } else {
                     // Right join is just a left join with tables swapped
-                    // Pass the original conditions - nested_loop_join_left_multi will handle the swap
+                    // Pass the original conditions - nested_loop_join_left_multi will handle the swap.
+                    // Tables are swapped, so the join-alias columns live in the `left_table`
+                    // argument here, not the `right_table` one.
                     self.nested_loop_join_left_multi(
                         right_table,
                         left_table,
                         &join_clause.condition.conditions,
                         &join_clause.alias,
+                        false, // swapped: join-alias table is the `left_table` argument
                     )
                 }
             }
@@ -313,6 +318,74 @@ impl HashJoinExecutor {
                 }
             }
             _ => None, // Complex expression - cannot use fast path
+        }
+    }
+
+    /// The table/alias qualifier of a simple column operand, if any
+    /// (e.g. `b` for `b.price`). Non-column or unqualified operands yield `None`.
+    fn expr_table_prefix(expr: &SqlExpression) -> Option<&str> {
+        match expr {
+            SqlExpression::Column(col) => col.table_prefix.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Decide which physical table a multi-condition ON operand should be
+    /// evaluated against (P7). Historically these paths evaluated the syntactic
+    /// left operand against the left table and the right operand against the
+    /// right table, which silently reversed predicates written right-table-first
+    /// (e.g. `b.price < a.price` became `a.price < b.price`). We instead route by
+    /// the operand's alias qualifier: an operand whose prefix is the join alias
+    /// belongs to the joined table; any other prefix belongs to the opposite
+    /// table. `join_alias_is_right` says which argument holds the join-alias
+    /// columns (the `right_table` arg for INNER/LEFT, the `left_table` arg for the
+    /// swapped RIGHT path). Unqualified operands fall back to the syntactic
+    /// position (`default_is_right`).
+    fn operand_uses_right(
+        &self,
+        expr: &SqlExpression,
+        join_alias: &Option<String>,
+        join_alias_is_right: bool,
+        default_is_right: bool,
+    ) -> bool {
+        if let (Some(prefix), Some(alias)) = (Self::expr_table_prefix(expr), join_alias.as_deref())
+        {
+            let matches_join_alias = if self.case_insensitive {
+                prefix.eq_ignore_ascii_case(alias)
+            } else {
+                prefix == alias
+            };
+            // Operand belongs to the join-alias table when its prefix matches,
+            // otherwise to the opposite side. Map that to right/left arg.
+            return if matches_join_alias {
+                join_alias_is_right
+            } else {
+                !join_alias_is_right
+            };
+        }
+        default_is_right
+    }
+
+    /// Evaluate a single ON-condition operand against the table it actually
+    /// belongs to (chosen via [`operand_uses_right`]), using the matching
+    /// per-row index. This is what makes `b.price < a.price` evaluate correctly
+    /// regardless of which side is written first (P7).
+    #[allow(clippy::too_many_arguments)]
+    fn eval_join_operand(
+        &self,
+        expr: &SqlExpression,
+        left_evaluator: &mut ArithmeticEvaluator,
+        right_evaluator: &mut ArithmeticEvaluator,
+        left_row_idx: usize,
+        right_row_idx: usize,
+        join_alias: &Option<String>,
+        join_alias_is_right: bool,
+        default_is_right: bool,
+    ) -> Result<DataValue> {
+        if self.operand_uses_right(expr, join_alias, join_alias_is_right, default_is_right) {
+            right_evaluator.evaluate(expr, right_row_idx)
+        } else {
+            left_evaluator.evaluate(expr, left_row_idx)
         }
     }
 
@@ -933,6 +1006,7 @@ impl HashJoinExecutor {
         right_table: Arc<DataTable>,
         conditions: &[crate::sql::parser::ast::SingleJoinCondition],
         join_alias: &Option<String>,
+        join_alias_is_right: bool,
     ) -> Result<DataTable> {
         let start = std::time::Instant::now();
 
@@ -1010,25 +1084,45 @@ impl HashJoinExecutor {
                 // Check all conditions - all must be true for a match
                 let mut all_conditions_met = true;
                 for condition in conditions.iter() {
-                    // Evaluate left expression for this row
-                    let left_value =
-                        match left_evaluator.evaluate(&condition.left_expr, left_row_idx) {
-                            Ok(val) => val,
-                            Err(_) => {
-                                all_conditions_met = false;
-                                break;
-                            }
-                        };
+                    // Route each operand to its owning table by alias qualifier
+                    // rather than syntactic position (P7). `left_expr` defaults to
+                    // the left table, `right_expr` to the right table, but an
+                    // explicit alias overrides that default.
+                    let left_val = self.eval_join_operand(
+                        &condition.left_expr,
+                        &mut left_evaluator,
+                        &mut right_evaluator,
+                        left_row_idx,
+                        right_row_idx,
+                        join_alias,
+                        join_alias_is_right,
+                        false, // left_expr defaults to the left table
+                    );
+                    let left_value = match left_val {
+                        Ok(val) => val,
+                        Err(_) => {
+                            all_conditions_met = false;
+                            break;
+                        }
+                    };
 
-                    // Evaluate right expression for this row
-                    let right_value =
-                        match right_evaluator.evaluate(&condition.right_expr, right_row_idx) {
-                            Ok(val) => val,
-                            Err(_) => {
-                                all_conditions_met = false;
-                                break;
-                            }
-                        };
+                    let right_val = self.eval_join_operand(
+                        &condition.right_expr,
+                        &mut left_evaluator,
+                        &mut right_evaluator,
+                        left_row_idx,
+                        right_row_idx,
+                        join_alias,
+                        join_alias_is_right,
+                        true, // right_expr defaults to the right table
+                    );
+                    let right_value = match right_val {
+                        Ok(val) => val,
+                        Err(_) => {
+                            all_conditions_met = false;
+                            break;
+                        }
+                    };
 
                     if !self.compare_values(&left_value, &right_value, &condition.operator) {
                         all_conditions_met = false;
@@ -1062,6 +1156,7 @@ impl HashJoinExecutor {
         right_table: Arc<DataTable>,
         conditions: &[crate::sql::parser::ast::SingleJoinCondition],
         join_alias: &Option<String>,
+        join_alias_is_right: bool,
     ) -> Result<DataTable> {
         let start = std::time::Instant::now();
 
@@ -1143,25 +1238,43 @@ impl HashJoinExecutor {
                 // Check all conditions - all must be true for a match
                 let mut all_conditions_met = true;
                 for condition in conditions.iter() {
-                    // Evaluate left expression for this row
-                    let left_value =
-                        match left_evaluator.evaluate(&condition.left_expr, left_row_idx) {
-                            Ok(val) => val,
-                            Err(_) => {
-                                all_conditions_met = false;
-                                break;
-                            }
-                        };
+                    // Route each operand to its owning table by alias qualifier
+                    // rather than syntactic position (P7).
+                    let left_val = self.eval_join_operand(
+                        &condition.left_expr,
+                        &mut left_evaluator,
+                        &mut right_evaluator,
+                        left_row_idx,
+                        right_row_idx,
+                        join_alias,
+                        join_alias_is_right,
+                        false, // left_expr defaults to the left table
+                    );
+                    let left_value = match left_val {
+                        Ok(val) => val,
+                        Err(_) => {
+                            all_conditions_met = false;
+                            break;
+                        }
+                    };
 
-                    // Evaluate right expression for this row
-                    let right_value =
-                        match right_evaluator.evaluate(&condition.right_expr, right_row_idx) {
-                            Ok(val) => val,
-                            Err(_) => {
-                                all_conditions_met = false;
-                                break;
-                            }
-                        };
+                    let right_val = self.eval_join_operand(
+                        &condition.right_expr,
+                        &mut left_evaluator,
+                        &mut right_evaluator,
+                        left_row_idx,
+                        right_row_idx,
+                        join_alias,
+                        join_alias_is_right,
+                        true, // right_expr defaults to the right table
+                    );
+                    let right_value = match right_val {
+                        Ok(val) => val,
+                        Err(_) => {
+                            all_conditions_met = false;
+                            break;
+                        }
+                    };
 
                     if !self.compare_values(&left_value, &right_value, &condition.operator) {
                         all_conditions_met = false;

--- a/tests/comparison/corpus/04_joins.toml
+++ b/tests/comparison/corpus/04_joins.toml
@@ -26,11 +26,23 @@ sql = "SELECT a.symbol AS s, a.price AS ap, b.price AS bp FROM trades a LEFT JOI
 id = "join_condition_operand_order"
 data = "trades.csv"
 sql = "SELECT a.price AS ap, b.price AS bp FROM trades a JOIN trades b ON a.symbol = b.symbol AND b.price < a.price"
-# P7 (NEW GAP): multi-condition nested-loop joins evaluate an extra condition's
-# operands by syntactic position (left_expr->left table, right_expr->right table),
-# ignoring the actual alias. `b.price < a.price` (right-table column first) is thus
-# evaluated as `a.price < b.price`, returning rows that violate the predicate.
-# Same query written `a.price > b.price` AGREEs. Affects INNER and LEFT paths.
+# P7 (FIXED 2026-07-12): multi-condition nested-loop joins used to evaluate an
+# extra condition's operands by syntactic position (left_expr->left table,
+# right_expr->right table), ignoring the actual alias, so `b.price < a.price`
+# (right-table column first) was silently evaluated as `a.price < b.price`.
+# Operands are now routed to their owning table by alias qualifier, so this
+# AGREEs regardless of operand order.
+
+[[case]]
+id = "right_join_multi_condition"
+data = "trades.csv"
+sql = "SELECT a.symbol AS s, a.price AS ap, b.price AS bp FROM trades a RIGHT JOIN trades b ON a.symbol = b.symbol AND a.price < b.price"
+# P8 (NEW, found 2026-07-12 while verifying P7): multi-condition RIGHT JOIN
+# diverges. The RIGHT path reuses the LEFT nested-loop with tables swapped and
+# passes the join alias unchanged, so the swapped-in table's columns are labelled
+# with the wrong alias (a.* values surface as bp, b.* as ap) and NULLs are emitted
+# for the wrong side (b instead of a). Row count matches but content differs.
+# Single-condition RIGHT joins (hash path) AGREE. Scoped as a separate follow-up.
 expect = "DIFFER"
 
 [[case]]

--- a/tests/comparison/engines.py
+++ b/tests/comparison/engines.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-SQL_CLI = PROJECT_ROOT / "target" / "release" / "sql-cli"
+# The release binary is `sql-cli` on Unix and `sql-cli.exe` on Windows.
+_SQL_CLI_BASE = PROJECT_ROOT / "target" / "release" / "sql-cli"
+SQL_CLI = _SQL_CLI_BASE.with_suffix(".exe") if sys.platform == "win32" else _SQL_CLI_BASE
 DATA_DIR = PROJECT_ROOT / "data"
 
 

--- a/tests/join_operand_order_tests.rs
+++ b/tests/join_operand_order_tests.rs
@@ -1,0 +1,149 @@
+//! Regression tests for P7: multi-condition join ON-clauses used to evaluate an
+//! extra condition's operands by *syntactic position* (left operand -> left
+//! table, right operand -> right table), ignoring the alias each operand was
+//! actually qualified with. So `b.price < a.price` (right-table column written
+//! first) was silently evaluated as `a.price < b.price` and returned rows that
+//! violated the predicate. See docs/SQL_PARITY.md :: P7.
+//!
+//! These are *self-consistency* tests: `b.price < a.price` and `a.price > b.price`
+//! are the same predicate, so they must return identical result sets. That
+//! property needs no reference engine, so it runs in plain `cargo test` — the
+//! gap the corpus (DuckDB differential, Parity CI job) couldn't cover locally.
+
+use sql_cli::data::datatable::{DataColumn, DataRow, DataTable, DataType, DataValue};
+use sql_cli::execution::{ExecutionContext, StatementExecutor};
+use sql_cli::sql::recursive_parser::Parser;
+use std::sync::Arc;
+
+/// A tiny `trades` base table so a base-table self-join (P4) resolves.
+fn trades_table() -> DataTable {
+    let mut table = DataTable::new("trades");
+    table.add_column(DataColumn::new("symbol").with_type(DataType::String));
+    table.add_column(DataColumn::new("price").with_type(DataType::Integer));
+    for (symbol, price) in [("A", 10), ("A", 20), ("A", 30), ("B", 5), ("B", 15)] {
+        let _ = table.add_row(DataRow {
+            values: vec![
+                DataValue::String(symbol.to_string()),
+                DataValue::Integer(price),
+            ],
+        });
+    }
+    table
+}
+
+/// Run a query and return its `(ap, bp)` rows sorted, treating NULL bp as `None`.
+fn ap_bp_rows(sql: &str) -> Vec<(i64, Option<i64>)> {
+    let context = &mut ExecutionContext::new(Arc::new(trades_table()));
+    let executor = StatementExecutor::new();
+    let mut parser = Parser::new(sql);
+    let stmt = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e}"));
+    let result = executor
+        .execute(stmt, context)
+        .unwrap_or_else(|e| panic!("exec failed for `{sql}`: {e}"));
+
+    let view = &result.dataview;
+    let src = view.source();
+    let ap_idx = src.get_column_index("ap").expect("ap column");
+    let bp_idx = src.get_column_index("bp").expect("bp column");
+
+    let as_int = |v: &DataValue| -> Option<i64> {
+        match v {
+            DataValue::Integer(i) => Some(*i),
+            DataValue::Float(f) => Some(*f as i64),
+            DataValue::Null => None,
+            other => panic!("unexpected price value: {other:?}"),
+        }
+    };
+
+    let mut rows: Vec<(i64, Option<i64>)> = (0..view.row_count())
+        .map(|r| {
+            let ap = as_int(&src.get_value(r, ap_idx).expect("ap value"))
+                .expect("ap is never NULL on the outer side");
+            let bp = as_int(&src.get_value(r, bp_idx).expect("bp value"));
+            (ap, bp)
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+#[test]
+fn inner_join_operand_order_is_symmetric() {
+    // Same predicate, operands written in opposite order — must agree.
+    let right_first = ap_bp_rows(
+        "SELECT a.price AS ap, b.price AS bp \
+         FROM trades a JOIN trades b ON a.symbol = b.symbol AND b.price < a.price",
+    );
+    let left_first = ap_bp_rows(
+        "SELECT a.price AS ap, b.price AS bp \
+         FROM trades a JOIN trades b ON a.symbol = b.symbol AND a.price > b.price",
+    );
+
+    assert_eq!(
+        right_first, left_first,
+        "`b.price < a.price` and `a.price > b.price` are the same predicate and must return the same rows"
+    );
+
+    // Expected set (per trades_table): A(20>10), A(30>10), A(30>20), B(15>5).
+    assert_eq!(
+        right_first,
+        vec![
+            (15, Some(5)),
+            (20, Some(10)),
+            (30, Some(10)),
+            (30, Some(20))
+        ]
+    );
+
+    // Every surviving row must actually satisfy `bp < ap`.
+    for (ap, bp) in &right_first {
+        let bp = bp.expect("INNER join never yields NULL bp");
+        assert!(
+            bp < *ap,
+            "row (ap={ap}, bp={bp}) violates b.price < a.price"
+        );
+    }
+}
+
+#[test]
+fn left_join_operand_order_is_symmetric() {
+    // The LEFT path had the same positional bug; unmatched left rows keep NULL bp.
+    let right_first = ap_bp_rows(
+        "SELECT a.price AS ap, b.price AS bp \
+         FROM trades a LEFT JOIN trades b ON a.symbol = b.symbol AND b.price < a.price",
+    );
+    let left_first = ap_bp_rows(
+        "SELECT a.price AS ap, b.price AS bp \
+         FROM trades a LEFT JOIN trades b ON a.symbol = b.symbol AND a.price > b.price",
+    );
+
+    assert_eq!(
+        right_first, left_first,
+        "LEFT JOIN must also be independent of ON-operand order"
+    );
+
+    // Every left row survives; the per-symbol minimum (A=10, B=5) has no smaller
+    // mate, so those emit NULL bp. A=30 matches two rows (10 and 20), so there are
+    // 4 matched rows + 2 NULL rows = 6. Matched rows must satisfy bp < ap.
+    assert_eq!(
+        right_first.len(),
+        6,
+        "4 matched rows + 2 unmatched (NULL) left rows"
+    );
+    for (ap, bp) in &right_first {
+        if let Some(bp) = bp {
+            assert!(
+                *bp < *ap,
+                "matched row (ap={ap}, bp={bp}) violates b.price < a.price"
+            );
+        }
+    }
+    // Exactly the two per-symbol minima are unmatched (NULL bp).
+    let nulls = right_first.iter().filter(|(_, bp)| bp.is_none()).count();
+    assert_eq!(
+        nulls, 2,
+        "the two per-symbol minimum-price rows have no smaller mate"
+    );
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -22,6 +22,9 @@ mod datetime_completion;
 #[path = "temp_table_qualified_join_tests.rs"]
 mod temp_table_qualified_join_tests;
 
+#[path = "join_operand_order_tests.rs"]
+mod join_operand_order_tests;
+
 #[path = "history_protection_integration.rs"]
 mod history_protection_integration;
 


### PR DESCRIPTION
…(P7)

Multi-condition nested-loop joins evaluated each extra ON condition's left operand against the left table and right operand against the right table by syntactic position, ignoring the alias each operand was qualified with. So `b.price < a.price` (right-table column written first) was silently evaluated as `a.price < b.price`, returning rows that violate the predicate. Writing the equivalent `a.price > b.price` agreed with the reference engine (DuckDB); the two orderings diverged.

Each operand is now routed to its owning table by alias qualifier (`operand_uses_right`): an operand whose prefix is the join alias belongs to the joined table, any other prefix to the opposite table, unqualified operands keep the old positional default. A `join_alias_is_right` flag threaded into `nested_loop_join_{inner,left}_multi` keeps this correct for the swapped RIGHT-join path. Orientation-independent, so chained joins work too.

- `04_joins.toml :: join_condition_operand_order` now AGREEs with DuckDB.
- Adds `tests/join_operand_order_tests.rs`: env-free self-consistency regression (operand order can't change the result) for INNER and LEFT, runnable under plain `cargo test` where the DuckDB corpus doesn't reach.
- engines.py: resolve `sql-cli.exe` on Windows so the harness runs there.
- Logs P8 (multi-condition RIGHT JOIN column/NULL mislabel, found while verifying P7) as OPEN with a pinned DIFFER corpus case; not fixed here.