### PR TITLE
fix(joins): correct column labels/NULL side for multi-condition RIGHT…

### DIFF
--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -178,23 +178,30 @@ annotation be removed.
   `cargo test`, independent of the DuckDB corpus.
 
 ### P8 — Multi-condition RIGHT JOIN mislabels columns and NULLs the wrong side
-- **Status:** 🔴 OPEN (found 2026-07-12 while verifying P7)
-- **Corpus:** `04_joins.toml :: right_join_multi_condition` (DIFFER)
+- **Status:** 🟢 FIXED (found 2026-07-12 while verifying P7; fixed 2026-07-17)
+- **Corpus:** `04_joins.toml :: right_join_multi_condition` (now AGREE)
 - **Observed:** `... a RIGHT JOIN trades b ON a.symbol = b.symbol AND a.price < b.price`
-  returns the right *number* of rows but wrong content: the outer (`a`) columns'
-  values surface under `b`'s alias and vice-versa, and NULLs are emitted for the
+  returned the right *number* of rows but wrong content: the outer (`a`) columns'
+  values surfaced under `b`'s alias and vice-versa, and NULLs were emitted for the
   wrong side (the `b` columns instead of the unmatched `a` columns). The RIGHT path
-  reuses `nested_loop_join_left_multi` with the tables swapped but passes the join
-  alias unchanged, so result-column aliasing and the outer-side NULL emission are
-  applied to the swapped-in table. This is **separate from P7** — the P7 operand
-  routing is orientation-correct here; the defect is in RIGHT-join column assembly.
-- **Scope note:** Single-condition RIGHT joins (the hash path) AGREE, so this is
-  confined to the multi-condition nested-loop RIGHT path. Not part of the P7 fix;
-  logged as a follow-up rather than expanded into this change.
-- **Decision:** **Fix** (candidate) — when swapping tables for RIGHT, also swap the
-  alias/outer-side bookkeeping so result columns and NULLs track the physical
-  tables. Silent wrong answer, but narrower blast radius than P7 (RIGHT + multi
-  condition only). Pinned as DIFFER meanwhile.
+  reused `nested_loop_join_left_multi` with the tables swapped but passed the join
+  alias unchanged, so both the `[joined, FROM]` result-column order and the
+  outer-side NULL emission were applied to the swapped-in table. This was
+  **separate from P7** — the P7 operand routing was orientation-correct here; the
+  defect was purely in RIGHT-join result-column assembly.
+- **Scope note:** Single-condition RIGHT joins (the hash path) always AGREEd, so
+  this was confined to the multi-condition nested-loop RIGHT path.
+- **Fix:** Added a dedicated `nested_loop_join_right_multi` in `hash_join.rs`
+  instead of reusing the swapped LEFT builder. It emits result columns in
+  `[FROM, joined]` order (matching INNER/LEFT), keeps the FROM table's qualified
+  names, applies the join alias only to the joined table on a name collision, and
+  iterates the joined table as the outer loop so every joined row is kept and the
+  FROM columns NULL-fill on no match. Operand routing (P7) is preserved. Data and
+  matching were already correct — this was a labelling/ordering change only.
+- **Regression test:** `tests/join_operand_order_tests.rs ::
+  right_join_multi_condition_labels_correct_side` pins that the `a.*`/`b.*` values
+  land under the correct aliases and NULLs fall on the FROM side, in plain
+  `cargo test` (independent of the DuckDB corpus).
 
 ---
 

--- a/src/data/hash_join.rs
+++ b/src/data/hash_join.rs
@@ -285,16 +285,19 @@ impl HashJoinExecutor {
                         &join_clause.alias,
                     )
                 } else {
-                    // Right join is just a left join with tables swapped
-                    // Pass the original conditions - nested_loop_join_left_multi will handle the swap.
-                    // Tables are swapped, so the join-alias columns live in the `left_table`
-                    // argument here, not the `right_table` one.
-                    self.nested_loop_join_left_multi(
-                        right_table,
-                        left_table,
+                    // Multi-condition RIGHT JOIN (P8). Historically this reused
+                    // `nested_loop_join_left_multi` with the tables swapped, which
+                    // matched/paired rows correctly but assembled the result in
+                    // `[joined, FROM]` column order and relabelled the swapped-in
+                    // FROM table with the join alias — so `a.*`/`b.*` labels (and
+                    // the NULL side) inverted. Use a dedicated builder that keeps
+                    // the physical FROM table first and only the joined table
+                    // carries the alias.
+                    self.nested_loop_join_right_multi(
+                        left_table,  // physical FROM table (a.*)
+                        right_table, // physical joined table (b.*, carries join alias)
                         &join_clause.condition.conditions,
                         &join_clause.alias,
-                        false, // swapped: join-alias table is the `left_table` argument
                     )
                 }
             }
@@ -1306,6 +1309,198 @@ impl HashJoinExecutor {
 
         info!(
             "Nested loop LEFT JOIN complete: {} matches, {} nulls in {:?}",
+            match_count,
+            null_count,
+            start.elapsed()
+        );
+
+        Ok(result)
+    }
+
+    /// Nested loop join for RIGHT JOIN with multiple conditions (P8).
+    ///
+    /// A RIGHT JOIN keeps every row of the *joined* table (`b`), NULL-filling the
+    /// FROM table (`a`) where nothing matches. It is tempting to model this as a
+    /// LEFT join with the two tables swapped, but that swaps the *result* layout
+    /// too: columns come out `[joined, FROM]` and the join alias lands on the
+    /// swapped-in FROM table, so `a.*`/`b.*` labels (and the NULL side) invert.
+    ///
+    /// This builder instead keeps the physical layout stable and inverts only the
+    /// iteration/NULL-fill direction:
+    ///   - result columns are `[FROM (a.*), joined (b.*)]`, exactly like INNER/LEFT,
+    ///     so the FROM table keeps its qualified names and only the joined table
+    ///     carries the join alias on a name collision;
+    ///   - the outer loop is over the joined table so every `b` row is emitted in
+    ///     `b` order, with the FROM columns NULLed when no `a` row matches.
+    ///
+    /// Operand routing (P7) is preserved: `a.price < b.price` evaluates against the
+    /// tables named by the aliases regardless of which side is written first.
+    fn nested_loop_join_right_multi(
+        &self,
+        from_table: Arc<DataTable>,
+        joined_table: Arc<DataTable>,
+        conditions: &[crate::sql::parser::ast::SingleJoinCondition],
+        join_alias: &Option<String>,
+    ) -> Result<DataTable> {
+        let start = std::time::Instant::now();
+
+        info!(
+            "Executing nested loop RIGHT JOIN with {} conditions: {} x {} rows",
+            conditions.len(),
+            from_table.row_count(),
+            joined_table.row_count()
+        );
+
+        // Create result table with columns in [FROM, joined] order.
+        let mut result = DataTable::new("joined");
+
+        // Add columns from the FROM table (a.*), unchanged — these are NULLable
+        // because unmatched joined rows NULL-fill this side.
+        for col in &from_table.columns {
+            result.add_column(DataColumn {
+                name: col.name.clone(),
+                data_type: col.data_type.clone(),
+                nullable: true, // Always nullable for outer join
+                unique_values: col.unique_values,
+                null_count: col.null_count,
+                metadata: col.metadata.clone(),
+                qualified_name: col.qualified_name.clone(),
+                source_table: col.source_table.clone(),
+            });
+        }
+
+        // Add columns from the joined table (b.*). On a name collision with a FROM
+        // column, qualify with the join alias — only the joined table takes it.
+        for col in &joined_table.columns {
+            if !from_table
+                .columns
+                .iter()
+                .any(|from_col| from_col.name == col.name)
+            {
+                result.add_column(DataColumn {
+                    name: col.name.clone(),
+                    data_type: col.data_type.clone(),
+                    nullable: col.nullable,
+                    unique_values: col.unique_values,
+                    null_count: col.null_count,
+                    metadata: col.metadata.clone(),
+                    qualified_name: col.qualified_name.clone(),
+                    source_table: col.source_table.clone(),
+                });
+            } else {
+                let (column_name, qualified_name) = if let Some(alias) = join_alias {
+                    (
+                        format!("{}.{}", alias, col.name),
+                        Some(format!("{}.{}", alias, col.name)),
+                    )
+                } else {
+                    (format!("{}_right", col.name), col.qualified_name.clone())
+                };
+                result.add_column(DataColumn {
+                    name: column_name,
+                    data_type: col.data_type.clone(),
+                    nullable: col.nullable,
+                    unique_values: col.unique_values,
+                    null_count: col.null_count,
+                    metadata: col.metadata.clone(),
+                    qualified_name,
+                    source_table: join_alias.clone().or_else(|| col.source_table.clone()),
+                });
+            }
+        }
+
+        // Create evaluators for both sides. The join-alias (joined) table is the
+        // "right" evaluator, so alias-qualified operands route correctly (P7).
+        let mut from_evaluator = ArithmeticEvaluator::new(&from_table);
+        let mut joined_evaluator = ArithmeticEvaluator::new(&joined_table);
+
+        // Outer loop over the joined table so every joined row is kept in order.
+        let mut match_count = 0;
+        let mut null_count = 0;
+
+        for (joined_row_idx, joined_row) in joined_table.rows.iter().enumerate() {
+            let mut found_match = false;
+
+            for (from_row_idx, from_row) in from_table.rows.iter().enumerate() {
+                // Check all conditions - all must be true for a match.
+                let mut all_conditions_met = true;
+                for condition in conditions.iter() {
+                    // Operands route by alias qualifier (P7). The FROM table is the
+                    // "left" evaluator, the joined (alias) table is the "right" one,
+                    // so `join_alias_is_right = true`. Unqualified operands fall back
+                    // to syntactic position (left_expr->FROM, right_expr->joined).
+                    let left_val = self.eval_join_operand(
+                        &condition.left_expr,
+                        &mut from_evaluator,
+                        &mut joined_evaluator,
+                        from_row_idx,
+                        joined_row_idx,
+                        join_alias,
+                        true,  // join-alias table is the "right" evaluator
+                        false, // left_expr defaults to the FROM table
+                    );
+                    let left_value = match left_val {
+                        Ok(val) => val,
+                        Err(_) => {
+                            all_conditions_met = false;
+                            break;
+                        }
+                    };
+
+                    let right_val = self.eval_join_operand(
+                        &condition.right_expr,
+                        &mut from_evaluator,
+                        &mut joined_evaluator,
+                        from_row_idx,
+                        joined_row_idx,
+                        join_alias,
+                        true, // join-alias table is the "right" evaluator
+                        true, // right_expr defaults to the joined table
+                    );
+                    let right_value = match right_val {
+                        Ok(val) => val,
+                        Err(_) => {
+                            all_conditions_met = false;
+                            break;
+                        }
+                    };
+
+                    if !self.compare_values(&left_value, &right_value, &condition.operator) {
+                        all_conditions_met = false;
+                        break;
+                    }
+                }
+
+                if all_conditions_met {
+                    // Emit [FROM values, joined values].
+                    let mut joined_result_row = DataRow { values: Vec::new() };
+                    joined_result_row.values.extend_from_slice(&from_row.values);
+                    joined_result_row
+                        .values
+                        .extend_from_slice(&joined_row.values);
+                    result.add_row(joined_result_row);
+                    match_count += 1;
+                    found_match = true;
+                }
+            }
+
+            // No matching FROM row: emit NULLs for the FROM columns, then the
+            // joined row's values.
+            if !found_match {
+                let mut joined_result_row = DataRow { values: Vec::new() };
+                for _ in 0..from_table.column_count() {
+                    joined_result_row.values.push(DataValue::Null);
+                }
+                joined_result_row
+                    .values
+                    .extend_from_slice(&joined_row.values);
+                result.add_row(joined_result_row);
+                null_count += 1;
+            }
+        }
+
+        info!(
+            "Nested loop RIGHT JOIN complete: {} matches, {} nulls in {:?}",
             match_count,
             null_count,
             start.elapsed()

--- a/tests/comparison/corpus/04_joins.toml
+++ b/tests/comparison/corpus/04_joins.toml
@@ -37,13 +37,12 @@ sql = "SELECT a.price AS ap, b.price AS bp FROM trades a JOIN trades b ON a.symb
 id = "right_join_multi_condition"
 data = "trades.csv"
 sql = "SELECT a.symbol AS s, a.price AS ap, b.price AS bp FROM trades a RIGHT JOIN trades b ON a.symbol = b.symbol AND a.price < b.price"
-# P8 (NEW, found 2026-07-12 while verifying P7): multi-condition RIGHT JOIN
-# diverges. The RIGHT path reuses the LEFT nested-loop with tables swapped and
-# passes the join alias unchanged, so the swapped-in table's columns are labelled
-# with the wrong alias (a.* values surface as bp, b.* as ap) and NULLs are emitted
-# for the wrong side (b instead of a). Row count matches but content differs.
-# Single-condition RIGHT joins (hash path) AGREE. Scoped as a separate follow-up.
-expect = "DIFFER"
+# P8 (FIXED 2026-07-17): multi-condition RIGHT JOIN used to reuse the LEFT
+# nested-loop with the tables swapped and the join alias unchanged, so the
+# swapped-in FROM table's columns were labelled with the wrong alias (a.* values
+# surfaced as bp, b.* as ap) and NULLs landed on the wrong side (b instead of a).
+# A dedicated `nested_loop_join_right_multi` now emits columns in [FROM, joined]
+# order with the alias only on the joined table, so this AGREEs.
 
 [[case]]
 id = "join_derived_table"

--- a/tests/join_operand_order_tests.rs
+++ b/tests/join_operand_order_tests.rs
@@ -9,6 +9,10 @@
 //! are the same predicate, so they must return identical result sets. That
 //! property needs no reference engine, so it runs in plain `cargo test` — the
 //! gap the corpus (DuckDB differential, Parity CI job) couldn't cover locally.
+//!
+//! The RIGHT-join test at the bottom pins P8: multi-condition RIGHT JOIN used to
+//! reuse the LEFT builder with the tables swapped, which inverted the `a.*`/`b.*`
+//! column labels and NULLed the wrong side. See docs/SQL_PARITY.md :: P8.
 
 use sql_cli::data::datatable::{DataColumn, DataRow, DataTable, DataType, DataValue};
 use sql_cli::execution::{ExecutionContext, StatementExecutor};
@@ -146,4 +150,94 @@ fn left_join_operand_order_is_symmetric() {
         nulls, 2,
         "the two per-symbol minimum-price rows have no smaller mate"
     );
+}
+
+/// Like `ap_bp_rows`, but the outer (kept) side is `bp` — a RIGHT JOIN keeps every
+/// `b` row and NULL-fills `ap`, so `ap` may be NULL and `bp` never is.
+fn ap_bp_rows_right(sql: &str) -> Vec<(Option<i64>, i64)> {
+    let context = &mut ExecutionContext::new(Arc::new(trades_table()));
+    let executor = StatementExecutor::new();
+    let mut parser = Parser::new(sql);
+    let stmt = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e}"));
+    let result = executor
+        .execute(stmt, context)
+        .unwrap_or_else(|e| panic!("exec failed for `{sql}`: {e}"));
+
+    let view = &result.dataview;
+    let src = view.source();
+    let ap_idx = src.get_column_index("ap").expect("ap column");
+    let bp_idx = src.get_column_index("bp").expect("bp column");
+
+    let as_int = |v: &DataValue| -> Option<i64> {
+        match v {
+            DataValue::Integer(i) => Some(*i),
+            DataValue::Float(f) => Some(*f as i64),
+            DataValue::Null => None,
+            other => panic!("unexpected price value: {other:?}"),
+        }
+    };
+
+    let mut rows: Vec<(Option<i64>, i64)> = (0..view.row_count())
+        .map(|r| {
+            let ap = as_int(&src.get_value(r, ap_idx).expect("ap value"));
+            let bp = as_int(&src.get_value(r, bp_idx).expect("bp value"))
+                .expect("bp is never NULL on the RIGHT outer side");
+            (ap, bp)
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+#[test]
+fn right_join_multi_condition_labels_correct_side() {
+    // P8: `a RIGHT JOIN b ON a.symbol = b.symbol AND a.price < b.price` keeps every
+    // `b` row. The `a.*` values must land under `ap` and `b.*` under `bp` (not the
+    // reverse), and unmatched rows must NULL the `a` (ap) side, not `b`.
+    let right_first = ap_bp_rows_right(
+        "SELECT a.price AS ap, b.price AS bp \
+         FROM trades a RIGHT JOIN trades b ON a.symbol = b.symbol AND a.price < b.price",
+    );
+    // Same predicate, operands written joined-side first — must agree (P7 holds
+    // through the RIGHT path too).
+    let joined_first = ap_bp_rows_right(
+        "SELECT a.price AS ap, b.price AS bp \
+         FROM trades a RIGHT JOIN trades b ON a.symbol = b.symbol AND b.price > a.price",
+    );
+    assert_eq!(
+        right_first, joined_first,
+        "RIGHT JOIN must be independent of ON-operand order"
+    );
+
+    // Expected (per trades_table): every b row kept; ap = a.price where a.price <
+    // b.price, else NULL. b=(A,10)->NULL, b=(A,20)->10, b=(A,30)->{10,20},
+    // b=(B,5)->NULL, b=(B,15)->5.
+    assert_eq!(
+        right_first,
+        vec![
+            (None, 5),
+            (None, 10),
+            (Some(5), 15),
+            (Some(10), 20),
+            (Some(10), 30),
+            (Some(20), 30),
+        ]
+    );
+
+    // The kept (bp) side is never NULL (enforced by the helper); only ap NULLs.
+    // If the labels were swapped (the P8 bug) the NULLs would appear under bp.
+    let ap_nulls = right_first.iter().filter(|(ap, _)| ap.is_none()).count();
+    assert_eq!(ap_nulls, 2, "two b rows have no smaller-priced a mate");
+
+    // Every matched row satisfies ap < bp — impossible if the values were swapped.
+    for (ap, bp) in &right_first {
+        if let Some(ap) = ap {
+            assert!(
+                *ap < *bp,
+                "matched row (ap={ap}, bp={bp}) violates a.price < b.price — labels swapped?"
+            );
+        }
+    }
 }


### PR DESCRIPTION
… JOIN (P8)

Multi-condition RIGHT JOIN reused nested_loop_join_left_multi with the two tables swapped but passed the join alias unchanged. The LEFT builder emits columns in [joined, FROM] order and aliases its *second* argument, which after the swap is the physical FROM table. As a result `a.*` values surfaced under `b`'s alias (and vice-versa) and NULLs landed on the joined side instead of the unmatched FROM side. Rows/matching were correct; only result-column assembly was wrong. Separate from P7 (operand routing was already orientation-correct).

Add a dedicated nested_loop_join_right_multi that emits columns in [FROM, joined] order (matching INNER/LEFT), keeps the FROM table's qualified names, applies the join alias only to the joined table on a name collision, and iterates the joined table as the outer loop so every joined row is kept and the FROM columns NULL-fill on no match. Operand routing (P7) is preserved.

- Corpus 04_joins.toml :: right_join_multi_condition flips DIFFER -> AGREE (parity contract holds at 72 cases).
- Env-free regression test right_join_multi_condition_labels_correct_side pins the label/NULL-side property in plain cargo test.
- docs/SQL_PARITY.md P8 marked FIXED.