### PR TITLE
fix(parser): reject trailing input instead of silently discarding it (P13 stage 1)

### DIFF
--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -76,11 +76,25 @@ Suggested fix order, by silent blast radius:
 | | Finding | Why first |
 |---|---|---|
 | ~~1~~ | ~~[P21](#p21) windows evaluated before `WHERE`~~ | ✅ **Fixed 2026-08-02** |
-| 2 | [P13](#p13) trailing tokens discarded | Silent, unbounded scope — any typo becomes a different working query |
-| 3 | [P18](#p18)/[P19](#p19) three-valued logic | Silent, and P18 produces *extra* rows |
-| 4 | [P24](#p24) `RANGE` treated as `ROWS` | Silent, hits the common `SUM(x) OVER (ORDER BY y)` running-total form |
-| 5 | [P14](#p14), [P16](#p16), [P17](#p17), [P20](#p20), [P23](#p23) | Smaller, self-contained, decisions already taken |
-| 6 | [P22](#p22), [P25](#p25), [P26](#p26), [P15](#p15) | Hard errors — visible, so less urgent than any of the above |
+| ~~2~~ | ~~[P13](#p13) trailing tokens discarded~~ | ✅ **Stage 1 done 2026-08-02**; stage 2 (`NULLS FIRST`/`LAST`) is item 6 below |
+| **3** | **[P30](#p30) `cond AND col IN (list)` returns 0 rows** | Silent, *still live*, and plain everyday SQL — returns nothing, which reads as "no data" rather than as a bug |
+| **4** | **[P28](#p28) `INTO #tmp` stages unfiltered rows** | Silent, and it *corrupts staged data* — the stage-then-combine workflow quietly carries rows the user filtered out |
+| **5** | **[P29](#p29) boolean operator after `IN (...)`** | Was silently dropping the rest of the `WHERE`; same area as P30, fix together |
+| **6** | **[P27](#p27) `OR` in `JOIN ... ON`** | Was a silent wrong answer until P13 stage 1 turned it into an error; shipped examples were affected |
+| 7 | [P18](#p18)/[P19](#p19) three-valued logic | Silent, and P18 produces *extra* rows |
+| 8 | [P24](#p24) `RANGE` treated as `ROWS` | Silent, hits the common `SUM(x) OVER (ORDER BY y)` running-total form |
+| 9 | [P14](#p14), [P16](#p16), [P17](#p17), [P20](#p20), [P23](#p23), P13 stage 2 | Smaller, self-contained, decisions already taken |
+| 10 | [P22](#p22), [P25](#p25), [P26](#p26), [P15](#p15) | Hard errors — visible, so less urgent than any of the above |
+
+P27–P30 jump the queue because all four were found *by* fixing something else,
+and all four are the dangerous shape: wrong data that looks plausible. Two of
+them hide themselves especially well — P28's "too many rows" invites adding
+another filter downstream until the output looks right, and P30's zero rows
+reads as "no matching data" rather than as a defect.
+
+That four serious silent bugs fell out of fixing one parser check is the
+strongest argument yet for the corpus approach: none of them had a failing unit
+test, and two had *passing* ones asserting the broken behaviour.
 
 P3 (correlated subqueries) stays gated on the R7/R6 structural work in
 [`ENGINE_REFACTORING.md`](ENGINE_REFACTORING.md) and is not part of this queue.
@@ -410,7 +424,8 @@ annotation be removed.
   input.
 
 ### P13 — Unparsed trailing tokens are silently discarded, taking later clauses with them
-- **Status:** 🔴 OPEN
+- **Status:** 🟡 STAGE 1 DONE (2026-08-02) — the parser now rejects trailing
+  input. Stage 2 (implement `NULLS FIRST` / `LAST`) outstanding.
 - **Corpus:** `08_ordering.toml :: trailing_garbage_token` (OURS_ONLY — the root
   cause, pinned directly), `order_by_nulls_last_limit` and
   `order_by_nulls_first_limit` (DIFFER — the instance users actually hit).
@@ -448,6 +463,75 @@ annotation be removed.
   the *lost LIMIT* only — the actual NULL ordering semantics remain untested.
   Tier 08 needs a fixture containing NULLs before that can be asserted either
   way.
+- **Stage 1, as built (2026-08-02).** `Parser::parse` now ends with
+  `expect_end_of_statement()`, which accepts an optional trailing `;` and
+  trailing comments and otherwise errors with the offending token and its
+  position. Three supporting fixes were needed, each a real bug in its own right:
+  1. **`;` became a real token.** It had been falling through the lexer's
+     catch-all as `Identifier(";")`. Adding `Token::Semicolon` required exactly
+     **one** exhaustive match arm across the whole tree — a neat measurement of
+     [R3](ENGINE_REFACTORING.md): everywhere else would have silently ignored it.
+  2. **`''` escapes in string literals were never implemented.** `read_string`
+     stopped at the first inner quote, so `'O''Brien'` lexed as two literals and
+     the parser discarded the second — the query meant `WHERE name = 'O'`. There
+     was a passing test asserting that query "should parse"; it did, into the
+     wrong thing. Now matches DuckDB on `'O''Brien'`, `'a''b''c'` and `''`.
+  3. **`;`-separated statements were being dropped.** Script batches split on
+     `GO` only, so `a; b;` inside one batch parsed `a` and silently discarded
+     `b`. `prime_numbers.sql` had a whole `SELECT` that had never run. Batches
+     are now sub-split on top-level `;` (quote- and comment-aware, so a `;`
+     inside a literal does not split), and `-q`/`-f` input holding more than one
+     statement routes to the script executor instead of the single-query path.
+     `GO` semantics are untouched, and statement *scope* is unaffected — the
+     executor builds one `ExecutionContext` per script, so `INTO #tmp` stays
+     visible across both separators (verified explicitly).
+- **What stage 1 exposed.** Beyond the above: `OR` in a `JOIN ... ON` clause is
+  not parsed ([P27](#p27)), and a stray `end` token had been sitting unnoticed in
+  `examples/case_when.sql`. Two examples (`prime_numbers`,
+  `physics_astronomy_showcase`) gained a result-set each once their dropped
+  statements started running; both were checked before re-capturing.
+
+### P27 — `OR` in a `JOIN ... ON` clause is not parsed
+- **Status:** 🔴 OPEN — **high priority: was a silent wrong answer until P13**
+- **Corpus:** `04_joins.toml :: join_on_or_condition` (GAP).
+- **Observed:** `... INNER JOIN b ON a.x = b.x OR a.y = b.y` parses only the
+  first condition. Until P13 stage 1 the `OR ...` remainder was **silently
+  discarded**, so the join ran on a *truncated predicate* and returned wrong
+  rows with no error. Since stage 1 it is a parse error, which is why this is
+  filed as a GAP rather than a DIFFER.
+- **Found:** 2026-08-02, by P13 stage 1 rejecting what it had previously
+  swallowed — in `examples/chemistry.sql`, which had been shipping wrong results
+  from `ON Year = latest_year OR Year = earliest_year`.
+- **Decision:** **Fix.** Join conditions should accept the same boolean
+  expressions `WHERE` does; `AND` already works (multi-condition joins are
+  well covered — see P7/P8), so this is `OR` specifically.
+
+### P28 — `SELECT ... INTO #tmp` stages the *unfiltered* rows
+- **Status:** 🔴 OPEN — **high priority: silent, and it corrupts staged data**
+- **Corpus:** none possible — `INTO #tmp` is our own extension and the reference
+  engine has no equivalent, so the oracle here is **our own behaviour
+  disagreeing with itself**. Needs a `cargo test` regression when fixed.
+- **Observed:** the `WHERE` clause is ignored when the result is staged:
+
+  ```sql
+  SELECT COUNT(*) FROM null_edges WHERE score IS NOT NULL;      -- 8  correct
+  SELECT id, score INTO #a FROM null_edges WHERE score IS NOT NULL;
+  SELECT COUNT(*) FROM #a;                                      -- 12 WRONG
+  ```
+
+  Both `INTO` placements (before `FROM`, and after all clauses) do it.
+- **Confirmed pre-existing**, not introduced by the P13 work: reproduced from a
+  clean build of `main` with all local changes stashed.
+- **Why it matters more than the row count suggests.** This is the
+  stage-then-combine workflow — pull several sources, stage each into a temp
+  table, join them at the end. Every staged table silently contains rows the
+  user filtered out, and the error only shows up as "too many rows" much later,
+  by which point the natural response is to add *more* filters downstream until
+  the output looks right — which masks it permanently.
+- **Same family as [P21](#p21):** a filter that is applied on the direct path but
+  not on a secondary one. Worth checking, when fixing, whether any other
+  consumer of a query result takes the same unfiltered route.
+- **Decision:** **Fix**, near the top of the queue.
 
 ### P14 — An ungrouped aggregate over an empty set returns no row
 - **Status:** 🔴 OPEN
@@ -781,6 +865,43 @@ annotation be removed.
   validity check; they belong to the post-aggregation stage. Note this is the
   same pipeline-position confusion as P21, approached from the other end — both
   come down to *when* windows are evaluated relative to the rest of the query.
+
+### P29 — A boolean operator after `IN (...)` is not parsed
+- **Status:** 🔴 OPEN — **high priority: was a silent wrong answer until P13**
+- **Corpus:** `02_where.toml :: in_list_then_and`, `in_subquery_then_and` (GAP).
+- **Observed:** `WHERE score IN (50, 70) AND team = 'alpha'` does not parse the
+  `AND ...`. Until P13 stage 1 the remainder was **silently discarded**, so the
+  query returned 4 rows (the `IN` alone) instead of 2, with no error. Same for
+  `OR`, and for the `IN (subquery)` form.
+- **Specific to `IN`.** `AND` is fine everywhere else — plain comparisons,
+  three-way chains, after `LIKE`, after `BETWEEN` — all verified. `NOT IN`
+  followed by `AND` also parses. It is the `IN` predicate that fails to hand
+  control back to the boolean-expression parser.
+- **Found:** 2026-08-02, by P13 stage 1 rejecting what it had been swallowing.
+  Surfaced through `tests/python_tests/test_subqueries.py`, whose two affected
+  tests had been passing while the filter they were testing was ignored — one
+  asserted only `count >= 0`, which is true whether or not the `AND` applies.
+- **Decision:** **Fix**, with [P30](#p30) — the two are the same area and a fix
+  should address both operand orders together.
+
+### P30 — `<cond> AND <col> IN (list)` returns zero rows
+- **Status:** 🔴 OPEN — **high priority: silent, and still live after P13**
+- **Corpus:** `02_where.toml :: and_then_in_list` (DIFFER).
+- **Observed:** with the operands the other way round from P29 the query
+  *parses* — and returns nothing:
+
+  ```sql
+  SELECT id, team, score FROM null_edges WHERE team = 'alpha' AND score IN (50, 70)
+  --  ours: 0 rows        DuckDB: (1, alpha, 50), (2, alpha, 50)
+  ```
+
+- **Distinct from P29.** That one is a parse gap and is now a hard error; this is
+  an *evaluation* bug that survives P13 stage 1 untouched. `where_in_with_null_col`
+  (an `IN` with no other condition) AGREEs, so `IN` alone is correct — it is the
+  combination that fails, and it fails **silently in the direction of returning
+  nothing**, which reads as "no matching data" rather than as a bug.
+- **Confirmed pre-existing**, reproduced from a clean build of `main`.
+- **Decision:** **Fix**, with P29.
 
 ---
 

--- a/examples/case_when.sql
+++ b/examples/case_when.sql
@@ -14,7 +14,7 @@ SELECT
         ELSE RPAD(value,5,'#')
     END as label
 FROM range(1,7);
-end
+GO
 
 
 

--- a/examples/expectations/physics_astronomy_showcase.json
+++ b/examples/expectations/physics_astronomy_showcase.json
@@ -46,6 +46,17 @@
   ],
   [
     {
+      "category": "=== ORBITAL DISTANCES ===",
+      "earth": 149597870700.0,
+      "jupiter": 778600000000.0,
+      "mars": 227900000000.0,
+      "mercury": 57910000000.0,
+      "saturn": 1433500000000.0,
+      "venus": 108200000000.0
+    }
+  ],
+  [
+    {
       "category": "=== PHYSICS CALCULATIONS ===",
       "earth_escape_velocity": 0.001770421859221024,
       "earth_orbital_velocity": 29789.111319772674,

--- a/examples/expectations/prime_numbers.json
+++ b/examples/expectations/prime_numbers.json
@@ -160,6 +160,13 @@
   ],
   [
     {
+      "hundred_is_prime": false,
+      "large_prime_check": true,
+      "seventeen_is_prime": true
+    }
+  ],
+  [
+    {
       "first_prime": 2,
       "hundredth_prime": 541,
       "tenth_prime": 29,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1426,10 +1426,14 @@ fn handle_non_interactive_query(
         parsed_args.query_arg.clone().unwrap()
     };
 
-    // Check if this is a multi-statement script (contains GO separator)
+    // Route to the script executor for a GO-separated batch file OR for anything
+    // holding more than one `;`-separated statement. GO stays exactly as it was;
+    // this only stops `a; b;` input from reaching the single-statement path,
+    // where the parser used to run `a` and silently discard `b` (P13).
     let is_script = query
         .lines()
-        .any(|line| line.trim().eq_ignore_ascii_case("go"));
+        .any(|line| line.trim().eq_ignore_ascii_case("go"))
+        || sql_cli::sql::script_parser::ScriptParser::is_multi_statement(&query);
 
     // Find the data file if provided. .tsv / .psv are routed through the CSV
     // loader which auto-detects the delimiter from the extension. When

--- a/src/sql/parser/lexer.rs
+++ b/src/sql/parser/lexer.rs
@@ -105,6 +105,10 @@ pub enum Token {
     // Operators
     Dot,
     Comma,
+    /// Statement terminator. Previously fell through the catch-all and lexed as
+    /// `Identifier(";")`, which the parser then silently ignored along with
+    /// everything after it (P13).
+    Semicolon,
     Colon,
     LeftParen,
     RightParen,
@@ -484,6 +488,18 @@ impl Lexer {
 
         while let Some(ch) = self.current_char {
             if ch == quote_char {
+                // SQL escapes a quote by doubling it: 'O''Brien' is one literal
+                // meaning O'Brien, and "a""b" likewise for quoted identifiers.
+                // Without this the literal ended at the first inner quote and the
+                // remainder became a SECOND literal — which the parser then
+                // silently discarded along with the rest of the statement (P13),
+                // turning `WHERE name = 'O''Brien'` into `WHERE name = 'O'`.
+                if self.peek(1) == Some(quote_char) {
+                    result.push(quote_char);
+                    self.advance(); // consume the first quote
+                    self.advance(); // consume the second
+                    continue;
+                }
                 self.advance(); // skip closing quote
                 break;
             }
@@ -574,6 +590,10 @@ impl Lexer {
             Some(',') => {
                 self.advance();
                 Token::Comma
+            }
+            Some(';') => {
+                self.advance();
+                Token::Semicolon
             }
             Some(':') => {
                 self.advance();
@@ -731,6 +751,10 @@ impl Lexer {
             Some(',') => {
                 self.advance();
                 Token::Comma
+            }
+            Some(';') => {
+                self.advance();
+                Token::Semicolon
             }
             Some(':') => {
                 self.advance();

--- a/src/sql/recursive_parser.rs
+++ b/src/sql/recursive_parser.rs
@@ -333,8 +333,46 @@ impl Parser {
             stmt
         };
 
+        self.expect_end_of_statement()?;
+
         self.trace_exit("parse", &Ok(&result));
         Ok(result)
+    }
+
+    /// Require that the whole input was consumed.
+    ///
+    /// Without this the parser stops at the first token it cannot place and
+    /// **silently ignores the rest of the statement** — so `ORDER BY x FROBNICATE
+    /// LIMIT 3` ran clean and dropped the LIMIT, and any typo or unsupported
+    /// clause quietly became a different query that succeeded (P13).
+    ///
+    /// A single trailing `;` is accepted: it terminates a statement rather than
+    /// being part of one. Script batches are already split on `GO` and have their
+    /// `;` stripped before reaching here, so this is for the `-q` path and for
+    /// anyone who ends a query out of habit.
+    fn expect_end_of_statement(&mut self) -> Result<(), String> {
+        if matches!(self.current_token, Token::Semicolon) {
+            self.advance();
+        }
+
+        // Trailing comments are content, not leftovers.
+        while matches!(
+            self.current_token,
+            Token::LineComment(_) | Token::BlockComment(_)
+        ) {
+            self.advance();
+        }
+
+        if matches!(self.current_token, Token::Eof) {
+            return Ok(());
+        }
+
+        Err(format!(
+            "Unexpected {} after end of statement (at position {}). \
+             The rest of the query would be ignored.",
+            describe_token(&self.current_token),
+            self.get_position()
+        ))
     }
 
     /// Public wrapper that accepts pre-collected comments and checks parens
@@ -2474,6 +2512,27 @@ fn analyze_statement(
     }
 
     (CursorContext::Unknown, None)
+}
+
+/// Render a token for an error message: the literal text where we have it, so the
+/// user sees what they typed rather than an internal variant name.
+fn describe_token(token: &Token) -> String {
+    if let Some(kw) = token.as_keyword_str() {
+        return format!("keyword '{kw}'");
+    }
+    match token {
+        Token::Identifier(s) | Token::QuotedIdentifier(s) => format!("'{s}'"),
+        Token::StringLiteral(s) => format!("string literal '{s}'"),
+        Token::NumberLiteral(s) => format!("number '{s}'"),
+        Token::Comma => "','".to_string(),
+        Token::Semicolon => "';'".to_string(),
+        Token::LeftParen => "'('".to_string(),
+        Token::RightParen => "')'".to_string(),
+        Token::Star => "'*'".to_string(),
+        Token::Dot => "'.'".to_string(),
+        Token::Eof => "end of input".to_string(),
+        other => format!("{other:?}"),
+    }
 }
 
 /// Helper function to find the last occurrence of a token type in the token stream

--- a/src/sql/script_parser.rs
+++ b/src/sql/script_parser.rs
@@ -137,6 +137,135 @@ impl ScriptParser {
         directives
     }
 
+    /// Split a `GO` batch into individual statements on top-level `;`.
+    ///
+    /// `GO` remains the batch separator it has always been — nothing about
+    /// existing scripts changes shape. This only recovers statements that were
+    /// previously glued together into one string, where the parser would parse
+    /// the first and **silently discard the rest** (P13). `prime_numbers.sql`
+    /// had a whole `SELECT` that never ran for exactly this reason.
+    ///
+    /// Quote- and comment-aware, so a `;` inside a string literal, a quoted
+    /// identifier, a line comment or a block comment does not split. Doubled
+    /// quotes (`'O''Brien'`) are handled as the escape they are rather than as
+    /// a close-then-reopen.
+    ///
+    /// Statement *scope* is unaffected: the script executor builds one
+    /// `ExecutionContext` for the whole file, so `SELECT ... INTO #tmp` stays
+    /// visible to later statements whether they are separated by `;` or `GO`.
+    fn split_on_semicolons(batch: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut current = String::new();
+        let mut chars = batch.chars().peekable();
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut in_line_comment = false;
+        let mut in_block_comment = false;
+
+        while let Some(ch) = chars.next() {
+            if in_line_comment {
+                current.push(ch);
+                if ch == '\n' {
+                    in_line_comment = false;
+                }
+                continue;
+            }
+            if in_block_comment {
+                current.push(ch);
+                if ch == '*' && chars.peek() == Some(&'/') {
+                    current.push(chars.next().unwrap());
+                    in_block_comment = false;
+                }
+                continue;
+            }
+            if in_single || in_double {
+                let quote = if in_single { '\'' } else { '"' };
+                current.push(ch);
+                if ch == quote {
+                    if chars.peek() == Some(&quote) {
+                        current.push(chars.next().unwrap()); // escaped quote
+                    } else if in_single {
+                        in_single = false;
+                    } else {
+                        in_double = false;
+                    }
+                }
+                continue;
+            }
+
+            match ch {
+                '\'' => {
+                    in_single = true;
+                    current.push(ch);
+                }
+                '"' => {
+                    in_double = true;
+                    current.push(ch);
+                }
+                '-' if chars.peek() == Some(&'-') => {
+                    in_line_comment = true;
+                    current.push(ch);
+                }
+                '/' if chars.peek() == Some(&'*') => {
+                    in_block_comment = true;
+                    current.push(ch);
+                }
+                ';' => {
+                    let stmt = current.trim().to_string();
+                    if !stmt.is_empty() {
+                        out.push(stmt);
+                    }
+                    current.clear();
+                }
+                _ => current.push(ch),
+            }
+        }
+
+        let last = current.trim().to_string();
+        if !last.is_empty() {
+            out.push(last);
+        }
+        out
+    }
+
+    /// True if the text holds more than one top-level statement, i.e. it needs
+    /// the script executor even though it has no `GO` separator.
+    ///
+    /// Without this a `;`-separated file routes to the single-query path, which
+    /// parses the whole thing as one statement — historically running only the
+    /// first and silently dropping the rest (P13).
+    #[must_use]
+    pub fn is_multi_statement(sql: &str) -> bool {
+        Self::split_on_semicolons(sql)
+            .iter()
+            .filter(|s| !Self::is_comment_only(s))
+            .count()
+            > 1
+    }
+
+    /// Turn one accumulated batch into zero or more `ScriptStatement`s.
+    /// Batch-level directives (e.g. `-- [SKIP]`) apply to every statement in it.
+    fn push_batch(batch: &str, pending_comments: &[String], statements: &mut Vec<ScriptStatement>) {
+        let batch = batch.trim();
+        if batch.is_empty() || Self::is_comment_only(batch) {
+            return;
+        }
+
+        let directives = Self::parse_directives(pending_comments);
+
+        for stmt in Self::split_on_semicolons(batch) {
+            if Self::is_comment_only(&stmt) {
+                continue;
+            }
+            let statement_type =
+                Self::parse_exit_statement(&stmt).unwrap_or(ScriptStatementType::Query(stmt));
+            statements.push(ScriptStatement {
+                statement_type,
+                directives: directives.clone(),
+            });
+        }
+    }
+
     /// Parse the script into ScriptStatements with directives
     /// GO must be on its own line (case-insensitive)
     pub fn parse_script_statements(&self) -> Vec<ScriptStatement> {
@@ -149,21 +278,7 @@ impl ScriptParser {
 
             // Check if this line is just "GO" (case-insensitive)
             if trimmed.eq_ignore_ascii_case("go") {
-                // Add the current statement if it's not empty
-                let statement = current_statement.trim().to_string();
-                if !statement.is_empty() && !Self::is_comment_only(&statement) {
-                    // Parse directives from pending comments
-                    let directives = Self::parse_directives(&pending_comments);
-
-                    // Check if this is an EXIT statement
-                    let statement_type = Self::parse_exit_statement(&statement)
-                        .unwrap_or_else(|| ScriptStatementType::Query(statement));
-
-                    statements.push(ScriptStatement {
-                        statement_type,
-                        directives,
-                    });
-                }
+                Self::push_batch(&current_statement, &pending_comments, &mut statements);
                 current_statement.clear();
                 pending_comments.clear();
             } else if trimmed.starts_with("--") {
@@ -183,19 +298,8 @@ impl ScriptParser {
             }
         }
 
-        // Don't forget the last statement if there's no trailing GO
-        let statement = current_statement.trim().to_string();
-        if !statement.is_empty() && !Self::is_comment_only(&statement) {
-            let directives = Self::parse_directives(&pending_comments);
-
-            let statement_type = Self::parse_exit_statement(&statement)
-                .unwrap_or_else(|| ScriptStatementType::Query(statement));
-
-            statements.push(ScriptStatement {
-                statement_type,
-                directives,
-            });
-        }
+        // Don't forget the last batch if there's no trailing GO
+        Self::push_batch(&current_statement, &pending_comments, &mut statements);
 
         statements
     }

--- a/src/text_navigation.rs
+++ b/src/text_navigation.rs
@@ -219,6 +219,7 @@ impl TextNavigator {
             Token::NumberLiteral(s) => s,
             Token::Star => "*",
             Token::Comma => ",",
+            Token::Semicolon => ";",
             Token::Colon => ":",
             Token::Dot => ".",
             Token::LeftParen => "(",

--- a/tests/comparison/corpus/02_where.toml
+++ b/tests/comparison/corpus/02_where.toml
@@ -81,3 +81,35 @@ sql = "SELECT symbol, price * 2 AS dbl FROM trades WHERE dbl IN (SELECT price * 
 # be an arbitrary expression (price*2), which the IN-subquery path never lifted,
 # so evaluate_in_list/between now evaluate an expression LHS via the arithmetic
 # evaluator. Now AGREE.
+
+# --- P29 / P30: IN combined with another condition ---
+
+[[case]]
+id = "in_list_then_and"
+data = "null_edges.csv"
+sql = "SELECT id FROM null_edges WHERE score IN (50, 70) AND team = 'alpha' ORDER BY id"
+expect = "GAP"
+# P29. A boolean operator FOLLOWING an `IN (...)` predicate is not parsed. Until
+# P13 stage 1 the remainder was silently discarded — this query returned 4 rows
+# (the `IN` alone) instead of 2, with no error. Now a parse error, which is why
+# it sits in GAP. `AND` works fine everywhere else, including after LIKE and
+# BETWEEN, so this is specific to IN.
+
+[[case]]
+id = "in_subquery_then_and"
+data = "null_edges.csv"
+sql = "SELECT id FROM null_edges WHERE score IN (SELECT score FROM null_edges WHERE id < 5) AND team = 'alpha' ORDER BY id"
+expect = "GAP"
+# P29, the subquery form — pinned separately because the IN-list and IN-subquery
+# paths are built differently (see P11) and a fix to one need not reach the other.
+
+[[case]]
+id = "and_then_in_list"
+data = "null_edges.csv"
+sql = "SELECT id, team, score FROM null_edges WHERE team = 'alpha' AND score IN (50, 70) ORDER BY id"
+expect = "DIFFER"
+# P30, and the more alarming of the pair: with the operands the other way round
+# this PARSES and returns ZERO rows where the answer is 2 (ids 1 and 2, both
+# score 50). Still live after P13 stage 1 — it is an evaluation bug, not a parse
+# one. `where_in_with_null_col` (IN with no other condition) AGREEs, so IN alone
+# is fine; it is the combination that fails.

--- a/tests/comparison/corpus/04_joins.toml
+++ b/tests/comparison/corpus/04_joins.toml
@@ -82,3 +82,19 @@ id = "from_less_derived_main"
 data = "trades.csv"
 sql = "SELECT x.k AS k, x.n AS n FROM (SELECT 1 AS k, 2 AS n) x"
 # Pins P5 for a FROM-less subquery used directly as the main FROM: one row.
+
+# --- P27: OR in a JOIN ON clause ---
+
+[[case]]
+id = "join_on_or_condition"
+data = "null_edges.csv"
+sql = "SELECT a.id AS aid, b.id AS bid FROM null_edges a INNER JOIN null_edges b ON a.id = b.id OR a.id = b.partner_id ORDER BY a.id, b.id"
+expect = "GAP"
+# P27, added 2026-08-02. Only the first condition is parsed. Until P13 stage 1
+# the `OR ...` remainder was silently DISCARDED, so the join ran on a truncated
+# predicate and returned wrong rows with no error — examples/chemistry.sql had
+# been shipping exactly that. It is a parse error now, which is why this sits in
+# GAP: a refusal is the correct intermediate state.
+#
+# AND in a join condition already works and is well covered by the P7/P8 cases
+# above, so this is specifically OR.

--- a/tests/comparison/corpus/08_ordering.toml
+++ b/tests/comparison/corpus/08_ordering.toml
@@ -89,39 +89,41 @@ sql = "SELECT id FROM null_edges ORDER BY id LIMIT 100"
 id = "order_by_nulls_last_no_limit"
 data = "international_sales.csv"
 sql = "SELECT country, amount FROM international_sales ORDER BY amount DESC NULLS LAST"
-# AGREEs, and this is the control that pins P13 down: with no LIMIT to lose,
-# the statement survives. NB it also agrees for a second, accidental reason —
-# see the P17 cases below — but on a NULL-free fixture only the first applies.
+expect = "GAP"
+# Was AGREE while P13 was live — the NULLS clause was silently ignored and, with
+# no LIMIT to lose, the remaining query happened to be the one the user meant.
+# Since P13 stage 1 (2026-08-02) we correctly REJECT the clause we do not
+# implement. Flips to AGREE when P13 stage 2 implements NULLS FIRST/LAST.
 
 [[case]]
 id = "order_by_nulls_last_limit"
 data = "international_sales.csv"
 sql = "SELECT country, amount FROM international_sales ORDER BY amount DESC NULLS LAST LIMIT 3"
-expect = "DIFFER"
-# P13. Returns all 20 rows instead of 3, with no error. Identical to
-# `order_by_limit` above but for the NULLS LAST clause.
+expect = "GAP"
+# Was P13: returned all 20 rows instead of 3, silently, because NULLS LAST took
+# the LIMIT with it. Now a parse error — the correct intermediate state, since a
+# refusal beats a different-query-that-succeeds. Flips to AGREE with stage 2.
 
 [[case]]
 id = "order_by_nulls_first_limit"
 data = "international_sales.csv"
 sql = "SELECT country, amount FROM international_sales ORDER BY amount NULLS FIRST LIMIT 3"
-expect = "DIFFER"
-# P13, the FIRST/ASC form — same defect, so the fix must clear both.
+expect = "GAP"
+# Same, the FIRST/ASC form.
 
 [[case]]
 id = "trailing_garbage_token"
 data = "international_sales.csv"
 sql = "SELECT country, amount FROM international_sales ORDER BY amount DESC FROBNICATE LIMIT 3"
-expect = "OURS_ONLY"
-# P13's ACTUAL root cause, pinned directly: `FROBNICATE` is not SQL by any
-# reading, yet we accept the statement and silently drop the LIMIT after it.
-# The reference engine rejects it, which is the correct behaviour and why this
-# sits in OURS_ONLY rather than DIFFER. NULLS LAST above is merely the instance
-# a user is likely to hit; this case is the defect.
+expect = "BOTH_ERR"
+# P13's root cause, pinned directly. `FROBNICATE` is not SQL by any reading, yet
+# we used to accept the statement and silently drop the LIMIT after it. Both
+# engines now reject it, which is the whole point of the fix — this case moving
+# OURS_ONLY -> BOTH_ERR is what "we stopped processing garbage" looks like.
 #
-# When P13 is fixed this becomes a parse error and moves to BOTH_ERR, and the
-# two NULLS cases above move DIFFER -> GAP (not AGREE) until NULLS ordering is
-# actually implemented. Expect that churn; it is progress, not regression.
+# NB `FROM international_sales FROBNICATE` still runs, correctly: there the word
+# is a table alias, which is valid SQL and accepted by the reference engine too.
+# The defect was only ever about tokens with nowhere to belong.
 
 # --- P16: ORDER BY <ordinal> is silently ignored ---
 

--- a/tests/python_tests/test_subqueries.py
+++ b/tests/python_tests/test_subqueries.py
@@ -7,6 +7,8 @@ import sys
 import tempfile
 import csv
 
+import pytest
+
 # Add parent directory to path to import test utilities
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -81,6 +83,13 @@ class TestInSubqueries:
         assert len(results) == 1, "Expected one result"
         assert results[0]['noble_gases'] == '7', "Should have 7 noble gases"
     
+    @pytest.mark.skip(
+        reason="P29: a boolean operator after IN (...) is not parsed. This test "
+        "passed for years while the AND clause was SILENTLY DISCARDED - it "
+        "asserted only that the count was >= 0, which held either way. P13 "
+        "stage 1 turned the silent drop into a parse error, which is what "
+        "surfaced it. Re-enable when P29 is fixed; see docs/SQL_PARITY.md."
+    )
     def test_in_subquery_with_filter(self):
         """Test IN subquery with additional WHERE conditions."""
         query = """
@@ -182,6 +191,12 @@ class TestComplexSubqueries:
             periods = [r['Period'] for r in results]
             assert len(periods) == len(set(periods)), "Each period should appear once"
     
+    @pytest.mark.skip(
+        reason="P29: a boolean operator after IN (...) is not parsed. The AND "
+        "joining the two IN conditions was silently discarded, so this only "
+        "ever tested the first one. Re-enable when P29 is fixed; see "
+        "docs/SQL_PARITY.md."
+    )
     def test_nested_in_conditions(self):
         """Test multiple IN/NOT IN conditions."""
         query = """


### PR DESCRIPTION
The parser stopped at the first token it couldn't place and **silently ignored the rest of the statement** — so any typo or unsupported clause became *a different query that succeeded*. `... ORDER BY amount DESC FROBNICATE LIMIT 3` ran clean and dropped the `LIMIT`.

`parse()` now ends with `expect_end_of_statement()`: an optional trailing `;` and trailing comments are fine, anything else errors with the offending token and its position.

## Three supporting fixes, each a real bug

- **`;` became a real token.** It had been falling through the lexer's catch-all as `Identifier(";")`. Adding `Token::Semicolon` needed exactly **one** exhaustive match arm in the entire tree — a neat measurement of R3, since everywhere else would have silently ignored a new variant.
- **`''` escapes in string literals were never implemented.** `read_string` stopped at the first inner quote, so `'O''Brien'` lexed as two literals and the parser discarded the second — the query meant `WHERE name = 'O'`. There was a **passing test asserting that query "should parse"**; it did, into the wrong thing. Now matches DuckDB on `'O''Brien'`, `'a''b''c'` and `''`.
- **`;`-separated statements were being dropped.** Batches split on `GO` only, so `a; b;` in one batch parsed `a` and discarded `b`. `prime_numbers.sql` had a whole `SELECT` that had never run. Batches now sub-split on top-level `;` — quote- and comment-aware, so a `;` inside a literal can't split — and multi-statement `-q`/`-f` input routes to the script executor.

## `GO` and temp-table scope are untouched

`GO`'s loop is unchanged; batches are only sub-split at flush time, so existing scripts keep their shape and merely regain statements they were losing.

Scope is safe by construction and I verified it rather than assumed: the executor builds **one** `ExecutionContext` per script, so `INTO #tmp` lifetime is per-script, not per-batch. Tested a temp table created before a `GO`, read after it, and read again from a second `;`-separated statement in the same batch — all three see it.

## Four more silent bugs found — filed, not fixed

Deliberately kept out of this branch to keep it bounded. All four are the dangerous shape: plausible-looking wrong data.

| | Finding | Status |
|---|---|---|
| **P27** | `OR` in a `JOIN ... ON` — predicate silently truncated | `examples/chemistry.sql` has been shipping wrong rows |
| **P28** | `SELECT ... INTO #tmp` stages the **unfiltered** rows | confirmed pre-existing from a clean `main` build |
| **P29** | boolean operator after `IN (...)` — rest of `WHERE` discarded | two python tests were *passing* while asserting it |
| **P30** | `cond AND col IN (list)` returns **0 rows** (DuckDB: 2) | **still live** — an evaluation bug, not a parse one |

**P28** is the nastiest in practice: it corrupts the stage-then-combine workflow, and it hides itself — "too many rows" invites adding another filter downstream until the output looks right, which masks the cause permanently. **P30** hides the other way: zero rows reads as "no matching data".

The two P29 python tests are **skipped with a reference**, not deleted — one had only asserted `count >= 0`, true whether or not the `AND` applied.

## Expected corpus churn — this is progress, not regression

Recorded in the tier comments up front:

- the two `NULLS` cases move **DIFFER → GAP**, not to AGREE — stage 2 (implementing `NULLS FIRST`/`LAST`) is still outstanding, and a refusal is the correct intermediate state
- `trailing_garbage_token` moves **OURS_ONLY → BOTH_ERR**, which is what "we stopped processing garbage" looks like

Corpus 152 → 155 cases; contract holds.

## Verification

- `cargo test` 688 + 417 + 1 green; `cargo fmt`/`clippy` clean, no new warnings
- Parity contract holds at 155 cases
- Examples: all FORMAL pass. Fixed a stray `end` token in `case_when.sql`, and re-captured `prime_numbers` and `physics_astronomy_showcase` — each gained a result-set once its dropped statement started running. New output checked (e.g. `IS_PRIME(17)=true, IS_PRIME(100)=false, IS_PRIME(997)=true`) before capturing rather than captured on faith.
- Python suite back to the exact known Windows-local baseline of 18 failures in the four known `.exe`-suffix files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
