### PR TITLE
fix(parser): bind IN at the comparison level (P29, P30)

### DIFF
--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -77,14 +77,14 @@ Suggested fix order, by silent blast radius:
 |---|---|---|
 | ~~1~~ | ~~[P21](#p21) windows evaluated before `WHERE`~~ | ✅ **Fixed 2026-08-02** |
 | ~~2~~ | ~~[P13](#p13) trailing tokens discarded~~ | ✅ **Stage 1 done 2026-08-02**; stage 2 (`NULLS FIRST`/`LAST`) is item 6 below |
-| **3** | **[P30](#p30) `cond AND col IN (list)` returns 0 rows** | Silent, *still live*, and plain everyday SQL — returns nothing, which reads as "no data" rather than as a bug |
+| ~~3~~ | ~~[P30](#p30) `cond AND col IN (list)` returns 0 rows~~ | ✅ **Fixed 2026-08-08** |
+| ~~5~~ | ~~[P29](#p29) boolean operator after `IN (...)`~~ | ✅ **Fixed 2026-08-08** — same bug as P30, one change closed both |
 | **4** | **[P28](#p28) `INTO #tmp` stages unfiltered rows** | Silent, and it *corrupts staged data* — the stage-then-combine workflow quietly carries rows the user filtered out |
-| **5** | **[P29](#p29) boolean operator after `IN (...)`** | Was silently dropping the rest of the `WHERE`; same area as P30, fix together |
-| **6** | **[P27](#p27) `OR` in `JOIN ... ON`** | Was a silent wrong answer until P13 stage 1 turned it into an error; shipped examples were affected |
-| 7 | [P18](#p18)/[P19](#p19) three-valued logic | Silent, and P18 produces *extra* rows |
+| **7** | **[P18](#p18)/[P19](#p19) three-valued logic** | Promoted: silent, P18 produces *extra* rows, and it now blocks two more corpus cases that the P29 fix uncovered |
 | 8 | [P24](#p24) `RANGE` treated as `ROWS` | Silent, hits the common `SUM(x) OVER (ORDER BY y)` running-total form |
 | 9 | [P14](#p14), [P16](#p16), [P17](#p17), [P20](#p20), [P23](#p23), P13 stage 2 | Smaller, self-contained, decisions already taken |
 | 10 | [P22](#p22), [P25](#p25), [P26](#p26), [P15](#p15) | Hard errors — visible, so less urgent than any of the above |
+| — | [P27](#p27) `OR` in `JOIN ... ON` | **Reclassified 2026-08-08 — not a quick win.** `JoinCondition` is a `Vec<SingleJoinCondition>` implicitly AND-ed, so there is nowhere in the AST to put an `OR`; it needs join conditions to become an expression, which reaches the join execution code. Sequence it with the R-log, not here |
 
 P27–P30 jump the queue because all four were found *by* fixing something else,
 and all four are the dangerous shape: wrong data that looks plausible. Two of
@@ -95,6 +95,21 @@ reads as "no matching data" rather than as a defect.
 That four serious silent bugs fell out of fixing one parser check is the
 strongest argument yet for the corpus approach: none of them had a failing unit
 test, and two had *passing* ones asserting the broken behaviour.
+
+**Two lessons from closing P29/P30 (2026-08-08), both worth generalising:**
+
+1. **Two findings filed as different classes were one bug.** P29 was "a parse
+   gap", P30 "an evaluation bug", and they were the same misplaced precedence
+   seen from two operand orders. Before fixing findings that sit in the same
+   area, check `--query-plan` on each — a mis-parse can yield a well-formed AST
+   that simply means something else, which is indistinguishable from an
+   evaluation fault by result alone.
+2. **Closing a parse error can expose a second, unrelated divergence beneath
+   it.** `in_subquery_then_and` went GAP → DIFFER, not GAP → AGREE, because the
+   parse error had been masking P18. That is progress and the case stays pinned,
+   now against P18. Expect this whenever a fix makes previously-unrunnable
+   queries run: budget for the finding underneath rather than assuming the
+   bucket goes straight to AGREE.
 
 P3 (correlated subqueries) stays gated on the R7/R6 structural work in
 [`ENGINE_REFACTORING.md`](ENGINE_REFACTORING.md) and is not part of this queue.
@@ -655,9 +670,10 @@ annotation be removed.
   the two ASC cases flip DIFFER → AGREE and their `expect` should be dropped.
 
 ### P18 — `= NULL` matches NULL rows instead of yielding UNKNOWN
-- **Status:** 🔴 OPEN
+- **Status:** 🔴 OPEN — **second site found 2026-08-08, see below**
 - **Corpus:** `10_aggregate_nulls.toml :: where_equals_null` (DIFFER).
   Baseline: `where_is_null` (AGREE).
+  Also `02_where.toml :: in_list_with_null_literal`, `in_subquery_then_and` (DIFFER).
 - **Observed:** `WHERE score = NULL` returns the four NULL-score rows. It is
   being treated as `IS NULL`. Under SQL three-valued logic `x = NULL` evaluates
   to UNKNOWN for **every** row — including rows where `x` is itself NULL — so
@@ -667,6 +683,19 @@ annotation be removed.
 - **Why it matters:** this is the direction that produces *extra* rows. A
   `WHERE col = <parameter>` that receives a NULL parameter silently returns the
   NULL rows instead of nothing — a wrong answer in the more dangerous direction.
+- **It also reaches `IN`, found 2026-08-08 while fixing P29/P30.** `IN` is built
+  on the same equality, so a NULL *in the list* matches every NULL row:
+  `score IN (50, NULL)` returns ids 1,2,3,10,11,12 where DuckDB returns 1,2.
+  This bites hardest in the subquery form, where the NULL is not visible in the
+  query text at all — `in_subquery_then_and`'s subquery yields a NULL among its
+  scores and the case DIFFERs by exactly that one row. The parse error fixed in
+  P29 had been hiding it.
+  The discriminating pair is `where_in_with_null_col` (AGREE): a NULL *column*
+  value against a list with no NULL in it is excluded correctly. The variable
+  that matters is a NULL in the list, not a NULL in the column.
+- **Scope note for the fix:** P19 already says to audit `IN`/`NOT IN`/`BETWEEN`/
+  `LIKE` together rather than patching one operator. This confirms it — the same
+  root equality is reached through at least three surfaces.
 
 ### P19 — `NOT IN` does not exclude NULLs
 - **Status:** 🔴 OPEN — same family as P18
@@ -867,8 +896,9 @@ annotation be removed.
   come down to *when* windows are evaluated relative to the rest of the query.
 
 ### P29 — A boolean operator after `IN (...)` is not parsed
-- **Status:** 🔴 OPEN — **high priority: was a silent wrong answer until P13**
-- **Corpus:** `02_where.toml :: in_list_then_and`, `in_subquery_then_and` (GAP).
+- **Status:** 🟢 FIXED 2026-08-08 — with [P30](#p30); they were one bug
+- **Corpus:** `02_where.toml :: in_list_then_and` (AGREE), `in_subquery_then_and`
+  (now DIFFER on [P18](#p18), see there).
 - **Observed:** `WHERE score IN (50, 70) AND team = 'alpha'` does not parse the
   `AND ...`. Until P13 stage 1 the remainder was **silently discarded**, so the
   query returned 4 rows (the `IN` alone) instead of 2, with no error. Same for
@@ -883,10 +913,17 @@ annotation be removed.
   asserted only `count >= 0`, which is true whether or not the `AND` applies.
 - **Decision:** **Fix**, with [P30](#p30) — the two are the same area and a fix
   should address both operand orders together.
+- **Fixed 2026-08-08**, branch `fix/p29-p30-in-precedence`. See P30 below for the
+  root cause; the "specific to `IN`" observation above was the clue that led to
+  it, since `NOT IN` was already handled at the correct precedence level.
 
 ### P30 — `<cond> AND <col> IN (list)` returns zero rows
-- **Status:** 🔴 OPEN — **high priority: silent, and still live after P13**
-- **Corpus:** `02_where.toml :: and_then_in_list` (DIFFER).
+- **Status:** 🟢 FIXED 2026-08-08 — same root cause as [P29](#p29)
+- **Corpus:** `02_where.toml :: and_then_in_list` (AGREE). Added with the fix:
+  `in_list_then_or`, `or_then_in_list`, `in_list_between_two_conditions` (AGREE).
+- **Regression test:** `tests/in_predicate_precedence_tests.rs` — six cases,
+  four of which fail against the unfixed parser (verified by stashing the fix);
+  the other two are controls that must pass either way.
 - **Observed:** with the operands the other way round from P29 the query
   *parses* — and returns nothing:
 
@@ -895,13 +932,32 @@ annotation be removed.
   --  ours: 0 rows        DuckDB: (1, alpha, 50), (2, alpha, 50)
   ```
 
-- **Distinct from P29.** That one is a parse gap and is now a hard error; this is
-  an *evaluation* bug that survives P13 stage 1 untouched. `where_in_with_null_col`
-  (an `IN` with no other condition) AGREEs, so `IN` alone is correct — it is the
-  combination that fails, and it fails **silently in the direction of returning
-  nothing**, which reads as "no matching data" rather than as a bug.
+- ~~**Distinct from P29.** That one is a parse gap; this is an *evaluation* bug.~~
+  **Wrong — they are the same bug.** Recorded because the misdiagnosis is
+  instructive: "it parses and returns wrong rows" was read as an evaluation
+  fault, but a mis-parse can produce a perfectly well-formed AST that *means*
+  something else. `--query-plan` settled it in one look and should have been the
+  first move.
+- **Root cause.** `IN` was applied at the top of `parse_expression`, *after* the
+  whole OR/AND hierarchy had been parsed:
+
+  ```rust
+  let mut left = self.parse_logical_or()?;
+  left = parse_in_operator(self, left)?;   // outside the hierarchy
+  ```
+
+  So `WHERE team = 'alpha' AND score IN (50, 70)` parsed as
+  `InList { expr: (team = 'alpha' AND score), values: [50, 70] }` — "is this
+  boolean one of 50 or 70?" — false for every row, hence zero rows. Reverse the
+  operands and the same misplacement instead leaves `AND team = 'alpha'`
+  unconsumed, which is P29. The operand order only decided whether the mis-parse
+  surfaced as a wrong answer or as leftover tokens.
+- **Fix.** Move the `IN` branch into `parse_comparison`, next to the `NOT IN`
+  branch that was already there and already correct, and drop the top-level call.
+  That `NOT IN` composed properly while `IN` did not was the diagnostic tell, and
+  it meant the correct implementation was sitting forty lines above the defect.
 - **Confirmed pre-existing**, reproduced from a clean build of `main`.
-- **Decision:** **Fix**, with P29.
+- **Decision:** **Fix**, with P29. Done.
 
 ---
 

--- a/src/sql/parser/expressions/comparison.rs
+++ b/src/sql/parser/expressions/comparison.rs
@@ -85,6 +85,19 @@ where
         }
     }
 
+    // Handle IN operator (P29/P30).
+    //
+    // IN binds at the comparison level, exactly like the NOT IN form above.
+    // It used to be applied at the top of `parse_expression`, *outside* the
+    // OR/AND hierarchy, which mis-parsed both operand orders:
+    //   `a = 1 AND b IN (..)` became InList{ expr: (a = 1 AND b), .. } -> 0 rows
+    //   `b IN (..) AND a = 1` left `AND a = 1` unconsumed -> parse error
+    if matches!(parser.current_token(), Token::In) {
+        let result = parse_in_operator(parser, left);
+        trace_parse_exit("parse_comparison", &result);
+        return result;
+    }
+
     // Handle IS NULL / IS NOT NULL
     if matches!(parser.current_token(), Token::Is) {
         parser.advance(); // consume IS

--- a/src/sql/recursive_parser.rs
+++ b/src/sql/recursive_parser.rs
@@ -25,7 +25,7 @@ use super::parser::expressions::arithmetic::{
 };
 use super::parser::expressions::case::{parse_case_expression as parse_case_expr, ParseCase};
 use super::parser::expressions::comparison::{
-    parse_comparison as parse_comparison_expr, parse_in_operator, ParseComparison,
+    parse_comparison as parse_comparison_expr, ParseComparison,
 };
 use super::parser::expressions::logical::{
     parse_logical_and as parse_logical_and_expr, parse_logical_or as parse_logical_or_expr,
@@ -1702,11 +1702,9 @@ impl Parser {
         self.trace_enter("parse_expression");
         // Start with logical OR as the lowest precedence operator
         // The hierarchy is: OR -> AND -> comparison -> additive -> multiplicative -> primary
-        let mut left = self.parse_logical_or()?;
-
-        // Handle IN operator (not preceded by NOT)
-        // This uses the modular comparison module
-        left = parse_in_operator(self, left)?;
+        // IN is handled down in parse_comparison, alongside NOT IN — applying it
+        // here (outside the OR/AND hierarchy) was P29/P30.
+        let left = self.parse_logical_or()?;
 
         let result = Ok(left);
         self.trace_exit("parse_expression", &result);

--- a/tests/comparison/corpus/02_where.toml
+++ b/tests/comparison/corpus/02_where.toml
@@ -88,28 +88,75 @@ sql = "SELECT symbol, price * 2 AS dbl FROM trades WHERE dbl IN (SELECT price * 
 id = "in_list_then_and"
 data = "null_edges.csv"
 sql = "SELECT id FROM null_edges WHERE score IN (50, 70) AND team = 'alpha' ORDER BY id"
-expect = "GAP"
-# P29. A boolean operator FOLLOWING an `IN (...)` predicate is not parsed. Until
-# P13 stage 1 the remainder was silently discarded — this query returned 4 rows
-# (the `IN` alone) instead of 2, with no error. Now a parse error, which is why
-# it sits in GAP. `AND` works fine everywhere else, including after LIKE and
-# BETWEEN, so this is specific to IN.
+# P29, FIXED 2026-08-08. A boolean operator FOLLOWING an `IN (...)` predicate was
+# not parsed: until P13 stage 1 the remainder was silently discarded (4 rows
+# instead of 2), after it the query was a hard error. Root cause was IN being
+# applied outside the OR/AND hierarchy — see P30 below, same bug.
 
 [[case]]
 id = "in_subquery_then_and"
 data = "null_edges.csv"
 sql = "SELECT id FROM null_edges WHERE score IN (SELECT score FROM null_edges WHERE id < 5) AND team = 'alpha' ORDER BY id"
-expect = "GAP"
+expect = "DIFFER"
 # P29, the subquery form — pinned separately because the IN-list and IN-subquery
 # paths are built differently (see P11) and a fix to one need not reach the other.
+# In the event the P29/P30 precedence fix covered both, since they share
+# `parse_in_operator`. Keep it: it is the control that proves that.
+#
+# It now DIFFERs on a *different* finding, which the parse error had been hiding:
+# the subquery yields the scores of ids 1-4, which include id 3's NULL, and
+# `NULL IN (.., NULL, ..)` matches for us where DuckDB gives UNKNOWN. 3 rows vs 2.
+# That is P18 (`= NULL` matches instead of yielding UNKNOWN) reaching IN through
+# the shared equality — see in_list_with_null_literal below, which isolates it
+# without a subquery. Re-pin to AGREE when P18 is fixed.
 
 [[case]]
 id = "and_then_in_list"
 data = "null_edges.csv"
 sql = "SELECT id, team, score FROM null_edges WHERE team = 'alpha' AND score IN (50, 70) ORDER BY id"
+# P30, FIXED 2026-08-08, and it was the more alarming of the pair: with the
+# operands this way round the query PARSED and returned ZERO rows where the
+# answer is 2 (ids 1 and 2, both score 50).
+#
+# Filed as an evaluation bug; it was not. IN was applied at the top of
+# parse_expression, outside the OR/AND hierarchy, so this parsed as
+#   InList { expr: (team = 'alpha' AND score), values: [50, 70] }
+# — "is this boolean one of 50 or 70?" — false for every row. Same root cause as
+# P29 above; the operand order only decided whether the mis-parse produced a
+# wrong answer or leftover tokens.
+
+[[case]]
+id = "in_list_then_or"
+data = "null_edges.csv"
+sql = "SELECT id, team, score FROM null_edges WHERE score IN (50) OR team = 'beta' ORDER BY id"
+# Added with the P29/P30 fix. The defect was in how IN bound relative to the
+# whole OR/AND hierarchy, so OR needs pinning in both operand orders too — AND
+# alone would not have caught a fix that only reached parse_logical_and.
+
+[[case]]
+id = "or_then_in_list"
+data = "null_edges.csv"
+sql = "SELECT id, team, score FROM null_edges WHERE team = 'beta' OR score IN (50) ORDER BY id"
+# Added with the P29/P30 fix; the OR mirror of and_then_in_list.
+
+[[case]]
+id = "in_list_with_null_literal"
+data = "null_edges.csv"
+sql = "SELECT id FROM null_edges WHERE score IN (50, NULL) ORDER BY id"
 expect = "DIFFER"
-# P30, and the more alarming of the pair: with the operands the other way round
-# this PARSES and returns ZERO rows where the answer is 2 (ids 1 and 2, both
-# score 50). Still live after P13 stage 1 — it is an evaluation bug, not a parse
-# one. `where_in_with_null_col` (IN with no other condition) AGREEs, so IN alone
-# is fine; it is the combination that fails.
+# P18, found 2026-08-08 while fixing P29/P30 — the literal-list form that
+# isolates what in_subquery_then_and trips over, with no subquery involved.
+# A NULL in the list matches every NULL-scored row: we return ids 1,2,3,10,11,12
+# where DuckDB returns 1,2. IN is built on the same equality as `= NULL`.
+#
+# Discriminating pair: where_in_with_null_col (tier 10) AGREEs — a NULL column
+# value against a list with NO NULL in it is excluded correctly. The variable
+# that matters is a NULL *in the list*, not a NULL in the column.
+
+[[case]]
+id = "in_list_between_two_conditions"
+data = "null_edges.csv"
+sql = "SELECT id, team, score FROM null_edges WHERE team = 'alpha' AND score IN (50, 70) AND id < 3 ORDER BY id"
+# Added with the P29/P30 fix. IN in the MIDDLE of a chain — the case that needs
+# parse_comparison to both consume the IN and hand control back to the AND loop.
+# The old top-level placement could not express this at all.

--- a/tests/in_predicate_precedence_tests.rs
+++ b/tests/in_predicate_precedence_tests.rs
@@ -1,0 +1,156 @@
+//! Regression tests for P29/P30 — `IN` must bind at the comparison level, so it
+//! composes with the surrounding boolean operators.
+//!
+//! `IN` used to be applied at the top of `parse_expression`, *after* the whole
+//! OR/AND hierarchy had been parsed. That produced two different failures
+//! depending on operand order:
+//!
+//!   `WHERE a = 1 AND b IN (..)` parsed as `InList { expr: (a = 1 AND b), .. }`
+//!       — "is this boolean one of the list values?" — false for every row, so
+//!       the query silently returned NOTHING.
+//!   `WHERE b IN (..) AND a = 1` left `AND a = 1` unconsumed, which was silently
+//!       discarded until P13 stage 1 and a hard error after it.
+//!
+//! These live in `cargo test` as well as the DuckDB corpus because the corpus
+//! only runs in the Parity CI job and needs a reference engine; P30 returned a
+//! plausible wrong answer (an empty result reads as "no matching data"), so it
+//! deserves a check that runs everywhere.
+
+use sql_cli::data::datatable::{DataColumn, DataRow, DataTable, DataType, DataValue};
+use sql_cli::execution::{ExecutionContext, StatementExecutor};
+use sql_cli::sql::recursive_parser::Parser;
+use std::sync::Arc;
+
+/// Rows chosen so that each predicate in a compound WHERE selects a *different*
+/// set: `team = 'alpha'` takes ids 1-3, `score IN (50, 70)` takes ids 1, 2, 4, 6.
+/// The intersection is ids 1 and 2, so a result of 3 rows means the `team` test
+/// was dropped, 4 rows means the `IN` was dropped, and 0 rows is the P30 shape.
+fn scores_table() -> DataTable {
+    let mut table = DataTable::new("scores");
+    table.add_column(DataColumn::new("id").with_type(DataType::Integer));
+    table.add_column(DataColumn::new("team").with_type(DataType::String));
+    table.add_column(DataColumn::new("score").with_type(DataType::Integer));
+
+    let rows: Vec<(i64, &str, Option<i64>)> = vec![
+        (1, "alpha", Some(50)),
+        (2, "alpha", Some(50)),
+        (3, "alpha", None),
+        (4, "beta", Some(70)),
+        (5, "beta", Some(30)),
+        (6, "beta", Some(70)),
+    ];
+
+    for (id, team, score) in rows {
+        let _ = table.add_row(DataRow {
+            values: vec![
+                DataValue::Integer(id),
+                DataValue::String(team.to_string()),
+                score.map_or(DataValue::Null, DataValue::Integer),
+            ],
+        });
+    }
+
+    table
+}
+
+/// Run `sql` against the fixture and return the surviving ids, in order.
+fn ids(sql: &str) -> Vec<i64> {
+    let mut context = ExecutionContext::new(Arc::new(scores_table()));
+    let executor = StatementExecutor::new();
+    let mut parser = Parser::new(sql);
+    let stmt = parser.parse().expect("parse failed");
+    let result = executor
+        .execute(stmt, &mut context)
+        .expect("execution failed");
+
+    let view = &result.dataview;
+    let id_col = view
+        .column_names()
+        .iter()
+        .position(|c| c == "id")
+        .expect("no id column");
+
+    (0..view.row_count())
+        .map(|r| {
+            view.get_cell_value(r, id_col)
+                .expect("null id")
+                .parse::<i64>()
+                .expect("id not an integer")
+        })
+        .collect()
+}
+
+#[test]
+fn condition_before_in_list_applies_both() {
+    // P30: this parsed fine and returned zero rows.
+    assert_eq!(
+        ids("SELECT id FROM scores WHERE team = 'alpha' AND score IN (50, 70) ORDER BY id"),
+        vec![1, 2],
+        "an empty result is the P30 signature: IN swallowed the AND expression \
+         and asked whether a boolean was one of the list values"
+    );
+}
+
+#[test]
+fn condition_after_in_list_applies_both() {
+    // P29: the `AND team = ...` was discarded, then (post-P13) a parse error.
+    assert_eq!(
+        ids("SELECT id FROM scores WHERE score IN (50, 70) AND team = 'alpha' ORDER BY id"),
+        vec![1, 2],
+        "4 ids here means the trailing AND was dropped and only the IN applied"
+    );
+}
+
+#[test]
+fn in_list_composes_with_or_in_both_operand_orders() {
+    // The defect was in how IN bound against the whole hierarchy, so OR needs
+    // pinning too — a fix reaching only parse_logical_and would pass the AND
+    // tests above and still break these.
+    // score IN (50) selects {1, 2}; team = 'beta' selects {4, 5, 6}; union is all
+    // but id 3, whose NULL score matches neither.
+    let expected = vec![1, 2, 4, 5, 6];
+    assert_eq!(
+        ids("SELECT id FROM scores WHERE score IN (50) OR team = 'beta' ORDER BY id"),
+        expected
+    );
+    assert_eq!(
+        ids("SELECT id FROM scores WHERE team = 'beta' OR score IN (50) ORDER BY id"),
+        expected
+    );
+}
+
+#[test]
+fn in_list_in_the_middle_of_a_chain() {
+    // Needs parse_comparison to consume the IN *and* hand control back to the
+    // AND loop. The old top-level placement could not express this at all.
+    assert_eq!(
+        ids("SELECT id FROM scores WHERE team = 'alpha' AND score IN (50, 70) AND id < 2 ORDER BY id"),
+        vec![1]
+    );
+}
+
+#[test]
+fn not_in_still_composes() {
+    // Control: NOT IN was always handled inside parse_comparison and was already
+    // correct. It is what showed the fix belonged there. This must not regress.
+    //
+    // NOT IN (70) selects {1, 2, 5} — id 3's NULL score is excluded, which is
+    // correct here and separately tracked as P19 for the general case — and
+    // team = 'beta' selects {4, 5, 6}, so only id 5 satisfies both. Picking 70
+    // rather than 50 keeps the two predicates disagreeing, so a dropped
+    // conjunct changes the answer.
+    assert_eq!(
+        ids("SELECT id FROM scores WHERE score NOT IN (70) AND team = 'beta' ORDER BY id"),
+        vec![5]
+    );
+}
+
+#[test]
+fn in_list_alone_is_unchanged() {
+    // Control: `IN` with no surrounding boolean always worked, including the
+    // exclusion of the NULL-scored id 3 against a list holding no NULL.
+    assert_eq!(
+        ids("SELECT id FROM scores WHERE score IN (50, 70) ORDER BY id"),
+        vec![1, 2, 4, 6]
+    );
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -199,6 +199,9 @@ mod test_window_context;
 #[path = "window_after_where_tests.rs"]
 mod window_after_where_tests;
 
+#[path = "in_predicate_precedence_tests.rs"]
+mod in_predicate_precedence_tests;
+
 #[path = "test_yanked_query.rs"]
 mod test_yanked_query;
 

--- a/tests/python_tests/test_in_between_operators.py
+++ b/tests/python_tests/test_in_between_operators.py
@@ -12,7 +12,11 @@ import pytest
 def run_query(query, data_file=None):
     """Execute a query and return the results."""
     base_dir = Path(__file__).parent.parent.parent
-    sql_cli = base_dir / "target" / "release" / "sql-cli"
+    # Windows needs the .exe suffix — without it every test in this file raised
+    # FileNotFoundError and silently never ran on a Windows box, while passing
+    # in CI. Same fix as tests/comparison/engines.py already carries.
+    suffix = ".exe" if sys.platform == "win32" else ""
+    sql_cli = base_dir / "target" / "release" / f"sql-cli{suffix}"
 
     if not sql_cli.exists():
         raise FileNotFoundError(f"sql-cli not found at {sql_cli}")

--- a/tests/python_tests/test_subqueries.py
+++ b/tests/python_tests/test_subqueries.py
@@ -7,8 +7,6 @@ import sys
 import tempfile
 import csv
 
-import pytest
-
 # Add parent directory to path to import test utilities
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -83,28 +81,43 @@ class TestInSubqueries:
         assert len(results) == 1, "Expected one result"
         assert results[0]['noble_gases'] == '7', "Should have 7 noble gases"
     
-    @pytest.mark.skip(
-        reason="P29: a boolean operator after IN (...) is not parsed. This test "
-        "passed for years while the AND clause was SILENTLY DISCARDED - it "
-        "asserted only that the count was >= 0, which held either way. P13 "
-        "stage 1 turned the silent drop into a parse error, which is what "
-        "surfaced it. Re-enable when P29 is fixed; see docs/SQL_PARITY.md."
-    )
     def test_in_subquery_with_filter(self):
-        """Test IN subquery with additional WHERE conditions."""
+        """Test IN subquery with additional WHERE conditions.
+
+        Re-enabled 2026-08-08 with the P29/P30 fix. This test passed for years
+        while the AND clause was SILENTLY DISCARDED, because it asserted only
+        that the count was >= 0 — true whether or not the filter applied. The
+        exact count below (verified against DuckDB) is what makes it a test.
+        """
         query = """
-        SELECT COUNT(*) as modern_radioactive 
-        FROM periodic_table 
+        SELECT COUNT(*) as modern_radioactive
+        FROM periodic_table
         WHERE Element IN (
             SELECT Element FROM periodic_table WHERE Year > 2000
         ) AND Radioactive = 'yes'
         """
         stdout, stderr, code = run_query(query)
         assert code == 0, f"Query failed: {stderr}"
-        
+
         results = parse_csv_output(stdout)
         assert len(results) == 1, "Expected one result"
-        assert int(results[0]['modern_radioactive']) >= 0, "Should have a valid count"
+        assert int(results[0]['modern_radioactive']) == 4, "Expected 4 (DuckDB agrees)"
+
+        # Every post-2000 element happens to be radioactive, so the count above
+        # is 4 with or without the AND — it cannot detect a dropped conjunct on
+        # its own. Flipping the value to 'no' must yield nothing. Selecting rows
+        # rather than COUNT(*) deliberately: an ungrouped aggregate over an empty
+        # set returns no row at all for us, which is P14 and a separate matter.
+        stdout, stderr, code = run_query("""
+        SELECT Element
+        FROM periodic_table
+        WHERE Element IN (
+            SELECT Element FROM periodic_table WHERE Year > 2000
+        ) AND Radioactive = 'no'
+        """)
+        assert code == 0, f"Query failed: {stderr}"
+        assert parse_csv_output(stdout) == [], \
+            "Rows here mean the AND was dropped and only the IN subquery applied"
     
     def test_in_subquery_multiple_values(self):
         """Test IN subquery that returns multiple values."""
@@ -191,14 +204,13 @@ class TestComplexSubqueries:
             periods = [r['Period'] for r in results]
             assert len(periods) == len(set(periods)), "Each period should appear once"
     
-    @pytest.mark.skip(
-        reason="P29: a boolean operator after IN (...) is not parsed. The AND "
-        "joining the two IN conditions was silently discarded, so this only "
-        "ever tested the first one. Re-enable when P29 is fixed; see "
-        "docs/SQL_PARITY.md."
-    )
     def test_nested_in_conditions(self):
-        """Test multiple IN/NOT IN conditions."""
+        """Test multiple IN/NOT IN conditions.
+
+        Re-enabled 2026-08-08 with the P29/P30 fix. The AND joining the two
+        subquery conditions was silently discarded, so this only ever tested the
+        first one — and `count > 0` held either way.
+        """
         query = """
         SELECT COUNT(*) as filtered
         FROM periodic_table
@@ -207,11 +219,13 @@ class TestComplexSubqueries:
         """
         stdout, stderr, code = run_query(query)
         assert code == 0, f"Query failed: {stderr}"
-        
+
         results = parse_csv_output(stdout)
         assert len(results) == 1, "Expected one result"
-        count = int(results[0]['filtered'])
-        assert count > 0, "Should have stable metals"
+        # 59 stable metals, verified against DuckDB. The first condition alone
+        # gives 92, so this number does detect a dropped conjunct.
+        assert int(results[0]['filtered']) == 59, \
+            "92 here means the NOT IN was dropped and only the metals filter applied"
 
 def run_tests():
     """Run all subquery tests."""


### PR DESCRIPTION
P29 and P30 were filed as separate findings — one a parse gap, one an evaluation bug — and turned out to be the same misplaced precedence seen from two operand orders.

## Root cause

`IN` was applied at the top of `parse_expression`, *after* the whole OR/AND hierarchy had been parsed:

```rust
let mut left = self.parse_logical_or()?;
left = parse_in_operator(self, left)?;   // outside the hierarchy
```

So `WHERE team = 'alpha' AND score IN (50, 70)` parsed as `InList { expr: (team = 'alpha' AND score), values: [50, 70] }` — "is this boolean one of 50 or 70?" — false for every row, so the query silently returned **nothing** (P30). With the operands reversed, the same misplacement instead left `AND team = 'alpha'` unconsumed: silently discarded until P13 stage 1, a hard error after it (P29).

**Fix:** move the `IN` branch into `parse_comparison`, next to the `NOT IN` branch that was already there and already correct. That `NOT IN` composed properly while `IN` did not was the diagnostic tell — the correct implementation was forty lines above the defect.

P30 was recorded as an evaluation bug. It wasn't: a mis-parse can produce a well-formed AST that simply *means* something else, which is indistinguishable from an evaluation fault by result alone. `--query-plan` settled it in one look. Noted in the doc so the next one goes faster.

## A second finding surfaced underneath

`in_subquery_then_and` went GAP → **DIFFER**, not GAP → AGREE. The parse error had been masking **P18**: the subquery yields a NULL among its scores, and `IN` is built on the same equality as `= NULL`, so a NULL in the list matches every NULL row (3 rows vs DuckDB's 2). Confirmed pre-existing and independent of this change. Re-pinned against P18, with `in_list_with_null_literal` added to isolate it without a subquery. P18 now documents the second site and moves up the fix queue.

## Parity

155 → **159 cases**, 120 → **125 AGREE**, contract holds.

- `in_list_then_and`, `and_then_in_list` now AGREE
- `in_list_then_or`, `or_then_in_list`, `in_list_between_two_conditions` added — pinning both OR operand orders and mid-chain `IN`, which the AND cases alone would not catch (a fix reaching only `parse_logical_and` would pass those and still be broken)
- `in_list_with_null_literal` added, pinned DIFFER against P18

## Tests

- **`tests/in_predicate_precedence_tests.rs`** — env-free coverage, since the corpus needs DuckDB and only runs in the Parity job. Four of its six cases fail against the unfixed parser (verified by stashing the fix); the other two are controls that must pass either way.
- **Two `test_subqueries.py` tests un-skipped** with assertions that test something — the previous `count >= 0` and `count > 0` held whether or not the `AND` applied. Values checked against DuckDB. One query can't discriminate even when fixed (every post-2000 element happens to be radioactive), so it gained a companion check that must return no rows.
- **`test_in_between_operators.py` gets the `.exe` suffix** — its 14 tests had been raising `FileNotFoundError` and never running on Windows while passing in CI, and they're the closest existing coverage of this change. Same fix `tests/comparison/engines.py` already carries.

## Verification

- `cargo test`: 688 + 423 green
- Examples: all FORMAL pass, no expectation churn. The 18 smoke failures were baselined against an unfixed build — byte-identical lists, none introduced here.
- `cargo fmt --check` clean; no new clippy warnings in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)