### PR TITLE
fix(engine): materialize the view, not its source table (P28, P31)

### DIFF
--- a/docs/ENGINE_REFACTORING.md
+++ b/docs/ENGINE_REFACTORING.md
@@ -290,6 +290,34 @@ feature work**, and so we can tell the difference between "this is awkward" and
 - **Decision:** Delete, don't migrate. Related to [R5](#r5) but logged separately
   because it is a coherent subsystem rather than scattered dead files.
 
+### R9 — Turning a `DataView` back into a `DataTable` was open-coded per caller
+- **Status:** 🟢 DONE (2026-08-16), alongside parity P28/P31
+- **Where:** `query_engine::materialize_view`, `non_interactive::limit_results`,
+  the `INTO` branch in `non_interactive::execute_script`
+- **Observed:** A `DataView` holds three pieces of state the source table does
+  not — the row filter, the column projection, and the LIMIT/OFFSET window — and
+  four places needed to collapse one back into a table. There was one correct
+  helper and **two hand-rolled copies that each dropped a different part of it**:
+  the `INTO` branch took `source_arc()` (dropping all three), `limit_results`
+  copied source *columns* with projected *row values* (dropping the projection,
+  and then silently discarding every mismatched row because `add_row`'s `Result`
+  went to `let _ =`). The one correct helper still missed LIMIT, because the
+  accessor it used, `visible_row_indices()`, is documented as the *pre*-limit set
+  — a name that reads like the answer and isn't.
+- **Impact:** Two live silent wrong answers ([P28](SQL_PARITY.md#p28),
+  [P31](SQL_PARITY.md#p31)) from one shape. Neither was a hard error: both
+  returned a well-formed result of the wrong size.
+- **Done:** `DataView` gained `windowed_row_indices()` (the post-limit set that
+  `row_count()` actually counts) and `with_max_rows()` (tighten the window,
+  keeping the tighter of two limits and preserving the offset).
+  `materialize_view` is now the only implementation, and all callers go through
+  it. The pre-limit accessor stays for callers that mean it, with its trap named
+  in the doc comment.
+- **Worth generalising:** an accessor whose name states the common case and whose
+  doc states the exception will be misused. `visible_row_indices()` was the
+  obvious-looking call at all four sites and the wrong one at three of them —
+  the same failure mode as [R3](#r3)'s catch-all arms, one layer down.
+
 ---
 
 ## Sequencing
@@ -338,3 +366,4 @@ AGREE count — which makes it safe to land well before the semantics change.
 | 2026-07-25 | R2: `where_alias_expander` migrated — closes P11; the four subquery-LHS variants came for free | — |
 | 2026-08-02 | Corpus tiers 08 (ordering), 09 (window/QUALIFY), 10 (aggregate/NULL) added; P13–P15 filed. 83 → 96 cases | — |
 | 2026-08-08 | R8 filed and stage 1 done: 830 lines of zero-caller legacy WHERE deleted (`where_clause_converter`, `where_evaluator`, `simple_where`) plus `DebugWidget`'s dead WHERE-AST code. No behaviour change | #47 |
+| 2026-08-16 | R9 filed and done: view→table materialization consolidated on `materialize_view`; `DataView` gains `windowed_row_indices`/`with_max_rows`. Closes parity P28 and P31 | — |

--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -79,7 +79,7 @@ Suggested fix order, by silent blast radius:
 | ~~2~~ | ~~[P13](#p13) trailing tokens discarded~~ | ✅ **Stage 1 done 2026-08-02**; stage 2 (`NULLS FIRST`/`LAST`) is item 6 below |
 | ~~3~~ | ~~[P30](#p30) `cond AND col IN (list)` returns 0 rows~~ | ✅ **Fixed 2026-08-08** |
 | ~~5~~ | ~~[P29](#p29) boolean operator after `IN (...)`~~ | ✅ **Fixed 2026-08-08** — same bug as P30, one change closed both |
-| **4** | **[P28](#p28) `INTO #tmp` stages unfiltered rows** | Silent, and it *corrupts staged data* — the stage-then-combine workflow quietly carries rows the user filtered out |
+| ~~4~~ | ~~[P28](#p28) `INTO #tmp` stages unfiltered rows~~ | ✅ **Fixed 2026-08-16** — turned out to stage the *whole source table*, and the sweep it prescribed found [P31](#p31) |
 | **7** | **[P18](#p18)/[P19](#p19) three-valued logic** | Promoted: silent, P18 produces *extra* rows, and it now blocks two more corpus cases that the P29 fix uncovered |
 | 8 | [P24](#p24) `RANGE` treated as `ROWS` | Silent, hits the common `SUM(x) OVER (ORDER BY y)` running-total form |
 | 9 | [P14](#p14), [P16](#p16), [P17](#p17), [P20](#p20), [P23](#p23), P13 stage 2 | Smaller, self-contained, decisions already taken |
@@ -95,6 +95,15 @@ reads as "no matching data" rather than as a defect.
 That four serious silent bugs fell out of fixing one parser check is the
 strongest argument yet for the corpus approach: none of them had a failing unit
 test, and two had *passing* ones asserting the broken behaviour.
+
+**A third lesson, from closing P28 (2026-08-16): a finding is written up from
+one probe, and inherits that probe's blind spot.** P28 was filed as "the WHERE is
+ignored" because it was diagnosed with `SELECT COUNT(*)`, which can only report a
+row count. The staged table was in fact the *entire source table* — every column,
+plus the ordering lost. Re-probe a finding from a different angle before scoping
+the fix; the entry describes the symptom that was looked for, not necessarily the
+defect. The same session's sweep for other consumers of the same route turned up
+[P31](#p31), a live zero-rows bug in the `--limit` flag that nobody had reported.
 
 **Two lessons from closing P29/P30 (2026-08-08), both worth generalising:**
 
@@ -522,10 +531,12 @@ annotation be removed.
   well covered — see P7/P8), so this is `OR` specifically.
 
 ### P28 — `SELECT ... INTO #tmp` stages the *unfiltered* rows
-- **Status:** 🔴 OPEN — **high priority: silent, and it corrupts staged data**
+- **Status:** 🟢 FIXED (2026-08-16)
 - **Corpus:** none possible — `INTO #tmp` is our own extension and the reference
   engine has no equivalent, so the oracle here is **our own behaviour
-  disagreeing with itself**. Needs a `cargo test` regression when fixed.
+  disagreeing with itself**. Pinned instead by
+  `tests/python_tests/test_temp_table_staging.py` (end-to-end, script path) and
+  `tests/view_materialization_tests.rs` (env-free, engine level).
 - **Observed:** the `WHERE` clause is ignored when the result is staged:
 
   ```sql
@@ -537,6 +548,10 @@ annotation be removed.
   Both `INTO` placements (before `FROM`, and after all clauses) do it.
 - **Confirmed pre-existing**, not introduced by the P13 work: reproduced from a
   clean build of `main` with all local changes stashed.
+- **Wider than filed.** The staged table was the **whole source table**, not a
+  filtered copy of the result: `SELECT id, score INTO #a` staged all six columns
+  of `null_edges`, and `ORDER BY` was lost too. The finding was written up from a
+  `COUNT(*)`, which could only ever show the row count.
 - **Why it matters more than the row count suggests.** This is the
   stage-then-combine workflow — pull several sources, stage each into a temp
   table, join them at the end. Every staged table silently contains rows the
@@ -544,9 +559,23 @@ annotation be removed.
   by which point the natural response is to add *more* filters downstream until
   the output looks right — which masks it permanently.
 - **Same family as [P21](#p21):** a filter that is applied on the direct path but
-  not on a secondary one. Worth checking, when fixing, whether any other
-  consumer of a query result takes the same unfiltered route.
-- **Decision:** **Fix**, near the top of the queue.
+  not on a secondary one.
+- **Root cause — one line, and a helper that was almost right.** A `DataView`
+  carries three things the source table does not: the `WHERE` filter, the
+  `SELECT` projection, and the `LIMIT`/`OFFSET` window. The script path
+  (`non_interactive.rs`) stored `final_view.source_arc()` — the *backing table*,
+  reached past the view entirely. `QueryEngine::materialize_view` is the shared
+  helper that does this correctly and **two other call sites already used it**;
+  the script path, which is the one that actually runs `INTO`, did not.
+- **A second defect underneath, in the shared helper.** `materialize_view`
+  iterated `visible_row_indices()`, documented as *"before limit/offset"*, so
+  `SELECT id INTO #a FROM t LIMIT 3` staged all 12 rows — through the two call
+  sites that were otherwise correct. Fixed by adding
+  `DataView::windowed_row_indices()` (the post-limit set, matching what
+  `row_count()` counts) and materializing from that. The pre-limit accessor is
+  still there for callers that mean it; its doc comment now names the trap.
+- **The sweep this entry asked for found a third site:** [P31](#p31), the
+  `--limit` flag. Recorded separately because the symptom is different.
 
 ### P14 — An ungrouped aggregate over an empty set returns no row
 - **Status:** 🔴 OPEN
@@ -958,6 +987,39 @@ annotation be removed.
   it meant the correct implementation was sitting forty lines above the defect.
 - **Confirmed pre-existing**, reproduced from a clean build of `main`.
 - **Decision:** **Fix**, with P29. Done.
+
+### P31 — `--limit` returns zero rows for any query with a `SELECT` list
+- **Status:** 🟢 FIXED (2026-08-16) — found by the [P28](#p28) sweep
+- **Corpus:** none possible — `--limit` is a CLI flag, not SQL. Pinned by
+  `tests/python_tests/test_temp_table_staging.py`.
+- **Observed:**
+
+  ```
+  sql-cli data/null_edges.csv -q "SELECT id, score FROM null_edges" --limit 3 -o csv
+  id,team,score,label,bonus,partner_id        <-- the source's columns
+                                              <-- and no rows at all
+  ```
+
+  `SELECT *` was fine, which is exactly why this survived: the flag works on the
+  shape people reach for when trying it out, and fails on every query that names
+  its columns.
+- **Root cause.** `non_interactive::limit_results` built the limited table from
+  `dataview.source().columns` — **all** source columns — but filled it with
+  `dataview.get_row(i)`, which returns only the **projected** values. Every row
+  then failed the column-count check inside `add_row`, whose `Result` was
+  discarded with `let _ =`. Hence zero rows under the wrong headers, reported as
+  a successful query.
+- **Fix.** Delete the hand-rolled copy loop and go through
+  `materialize_view` like the other three consumers, over the view narrowed by a
+  new `DataView::with_max_rows` — which takes the *tighter* of the SQL `LIMIT`
+  and the CLI flag and leaves any `OFFSET` alone, preserving the old
+  `row_count().min(limit)` intent.
+- **Same root cause as P28, different symptom.** Both are "a `DataView` was
+  turned back into a `DataTable` by reaching past the view". P28 kept the
+  source's rows; this kept the source's columns. That is the argument for one
+  materialization helper rather than a copy loop per call site — and it is what
+  the P28 entry's "check whether any other consumer takes the same route" note
+  was for. **The note worked; make that sweep routine.**
 
 ---
 

--- a/src/data/data_view.rs
+++ b/src/data/data_view.rs
@@ -1391,6 +1391,30 @@ impl DataView {
         &self.visible_rows
     }
 
+    /// Tighten the row window to at most `max_rows`, preserving any existing
+    /// LIMIT/OFFSET — the tighter of the two wins, and the offset is untouched.
+    #[must_use]
+    pub fn with_max_rows(mut self, max_rows: usize) -> Self {
+        self.limit = Some(self.row_count().min(max_rows));
+        self
+    }
+
+    /// Get visible row indices *after* limit/offset — the rows a consumer
+    /// actually sees, and what `row_count()` counts.
+    ///
+    /// Prefer this over `visible_row_indices()` whenever the result is being
+    /// turned back into data (materializing a temp table, exporting); the
+    /// pre-limit set silently reintroduces rows the query excluded.
+    #[must_use]
+    pub fn windowed_row_indices(&self) -> &[usize] {
+        let start = self.offset.min(self.visible_rows.len());
+        let end = match self.limit {
+            Some(limit) => start.saturating_add(limit).min(self.visible_rows.len()),
+            None => self.visible_rows.len(),
+        };
+        &self.visible_rows[start..end]
+    }
+
     /// Optimize memory usage by shrinking vectors to fit
     pub fn shrink_to_fit(&mut self) {
         self.visible_rows.shrink_to_fit();

--- a/src/data/query_engine.rs
+++ b/src/data/query_engine.rs
@@ -1566,8 +1566,9 @@ impl QueryEngine {
             result_table.add_column(new_col);
         }
 
-        // Copy visible rows
-        for row_idx in view.visible_row_indices() {
+        // Copy visible rows, honouring the view's LIMIT/OFFSET window as well as
+        // its filter — `visible_row_indices()` is the *pre-limit* set (parity P28).
+        for row_idx in view.windowed_row_indices() {
             let source_row = &source.rows[*row_idx];
             let mut new_row = DataRow { values: Vec::new() };
 

--- a/src/non_interactive.rs
+++ b/src/non_interactive.rs
@@ -1001,8 +1001,32 @@ pub fn execute_script(config: NonInteractiveConfig) -> Result<()> {
 
                 // Phase 1: Check if this is an INTO statement - store result in temp table
                 if let Some(into_table) = &into_table {
-                    // Get the source table from the DataView - this contains the query result
-                    let result_table = final_view.source_arc();
+                    // Materialize the *view*, not its backing table. The view carries the
+                    // WHERE filter and the SELECT projection; `source_arc()` handed back the
+                    // whole unfiltered, unprojected source table (parity P28).
+                    use crate::data::query_engine::QueryEngine;
+                    let engine = QueryEngine::with_case_insensitive(config.case_insensitive);
+                    let result_table = match engine.materialize_view(final_view.clone()) {
+                        Ok(table) => std::sync::Arc::new(table),
+                        Err(e) => {
+                            let msg = format!(
+                                "Query {} failed: could not materialize {}: {}",
+                                statement_num, into_table.name, e
+                            );
+                            if matches!(config.output_format, OutputFormat::Table) {
+                                output.push(msg.clone());
+                            } else {
+                                eprintln!("{}", msg);
+                            }
+                            script_result.add_failure(
+                                statement_num,
+                                statement.to_string(),
+                                msg,
+                                exec_time,
+                            );
+                            break;
+                        }
+                    };
                     let row_count = result_table.row_count();
 
                     // Phase 1: Use context.store_temp_table() instead of temp_tables.insert()
@@ -1213,22 +1237,16 @@ fn load_data_file(path: &str, delimiter_override: Option<u8>) -> Result<DataTabl
 
 /// Limit the number of rows in results
 fn limit_results(dataview: &DataView, limit: usize) -> Result<DataTable> {
-    let source = dataview.source();
-    let mut limited_table = DataTable::new(&source.name);
-
-    // Copy columns
-    for col in &source.columns {
-        limited_table.add_column(col.clone());
-    }
-
-    // Copy limited rows
-    let rows_to_copy = dataview.row_count().min(limit);
-    for i in 0..rows_to_copy {
-        if let Some(row) = dataview.get_row(i) {
-            let _ = limited_table.add_row(row.clone());
-        }
-    }
-
+    // This used to copy *all source columns* while copying *projected rows*, so
+    // any query with a SELECT list produced a column/value length mismatch and
+    // every row was silently rejected — 0 rows under the source's headers
+    // (parity P31, same family as P28). Materializing the view keeps the
+    // projection and the row values in step.
+    use crate::data::query_engine::QueryEngine;
+    let name = dataview.source().name.clone();
+    let mut limited_table =
+        QueryEngine::new().materialize_view(dataview.clone().with_max_rows(limit))?;
+    limited_table.name = name;
     Ok(limited_table)
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -22,6 +22,9 @@ mod datetime_completion;
 #[path = "temp_table_qualified_join_tests.rs"]
 mod temp_table_qualified_join_tests;
 
+#[path = "view_materialization_tests.rs"]
+mod view_materialization_tests;
+
 #[path = "join_operand_order_tests.rs"]
 mod join_operand_order_tests;
 

--- a/tests/python_tests/test_temp_table_staging.py
+++ b/tests/python_tests/test_temp_table_staging.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Regression tests for SELECT ... INTO #tmp staging (parity P28) and for the
+--limit flag (parity P31).
+
+Both bugs had the same shape: a DataView carries the WHERE filter, the SELECT
+projection and the LIMIT window, and the code that turned that view back into a
+table reached past it to the underlying source table. Staging then quietly
+carried rows and columns the query had excluded.
+
+These go through the real binary because the defect lived in the script
+execution path (src/non_interactive.rs), not in the engine.
+"""
+
+import csv
+import os
+import subprocess
+import sys
+import tempfile
+from io import StringIO
+
+_BIN = os.path.join(os.path.dirname(__file__), "../../target/release/sql-cli")
+SQL_CLI = _BIN + ".exe" if sys.platform == "win32" else _BIN
+
+# 12 rows; 8 have a non-NULL score.
+CSV_CONTENT = """id,team,score,label
+1,alpha,50,delta
+2,alpha,50,
+3,alpha,,charlie
+4,beta,70,bravo
+5,beta,30,
+6,beta,70,alpha
+7,,90,echo
+8,,10,foxtrot
+9,gamma,20,golf
+10,gamma,,
+11,delta,,
+12,delta,,
+"""
+
+
+def _data_file():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+        f.write(CSV_CONTENT)
+        return f.name
+
+
+def run_script(statements, data_file):
+    """Run SQL statements as a GO-separated script; return the last result."""
+    script = "".join(f"{s};\nGO\n" for s in statements)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".sql", delete=False) as f:
+        f.write(script)
+        script_file = f.name
+    try:
+        result = subprocess.run(
+            [SQL_CLI, data_file, "-f", script_file, "-o", "csv"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(f"Script failed: {result.stderr}")
+        return result.stdout
+    finally:
+        os.unlink(script_file)
+
+
+def run_query(query, data_file, extra_args=()):
+    result = subprocess.run(
+        [SQL_CLI, data_file, "-q", query, "-o", "csv", *extra_args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"Query failed: {result.stderr}")
+    return result.stdout
+
+
+def parse_last_result(stdout):
+    """Parse the final CSV block emitted by a script run."""
+    blocks = [b for b in stdout.strip().split("\n\n") if b.strip()]
+    rows = list(csv.DictReader(StringIO(blocks[-1])))
+    return rows
+
+
+def test_into_honours_where():
+    """P28: the staged table must not carry rows the WHERE excluded."""
+    data = _data_file()
+    try:
+        out = run_script(
+            [
+                "SELECT id, score INTO #a FROM null_edges WHERE score IS NOT NULL",
+                "SELECT COUNT(*) AS n FROM #a",
+            ],
+            data,
+        )
+        rows = parse_last_result(out)
+        assert rows[0]["n"] == "8", f"expected 8 staged rows, got {rows[0]['n']}"
+    finally:
+        os.unlink(data)
+
+
+def test_into_honours_select_list():
+    """P28: the staged table must have only the projected columns."""
+    data = _data_file()
+    try:
+        out = run_script(
+            [
+                "SELECT id, score INTO #a FROM null_edges WHERE score IS NOT NULL",
+                "SELECT * FROM #a",
+            ],
+            data,
+        )
+        rows = parse_last_result(out)
+        assert len(rows) == 8, f"expected 8 rows, got {len(rows)}"
+        assert list(rows[0].keys()) == ["id", "score"], (
+            f"staged columns should be the projection, got {list(rows[0].keys())}"
+        )
+    finally:
+        os.unlink(data)
+
+
+def test_into_honours_limit():
+    """P28: LIMIT is part of the result, so it must be part of what is staged."""
+    data = _data_file()
+    try:
+        out = run_script(
+            [
+                "SELECT id INTO #a FROM null_edges LIMIT 3",
+                "SELECT COUNT(*) AS n FROM #a",
+            ],
+            data,
+        )
+        rows = parse_last_result(out)
+        assert rows[0]["n"] == "3", f"expected 3 staged rows, got {rows[0]['n']}"
+    finally:
+        os.unlink(data)
+
+
+def test_into_after_clauses_honours_where():
+    """P28: the trailing INTO placement takes the same path."""
+    data = _data_file()
+    try:
+        out = run_script(
+            [
+                "SELECT id, score FROM null_edges WHERE score IS NOT NULL INTO #b",
+                "SELECT COUNT(*) AS n FROM #b",
+            ],
+            data,
+        )
+        rows = parse_last_result(out)
+        assert rows[0]["n"] == "8", f"expected 8 staged rows, got {rows[0]['n']}"
+    finally:
+        os.unlink(data)
+
+
+def test_into_preserves_order_by():
+    """Control: staging must keep the ordering the query asked for."""
+    data = _data_file()
+    try:
+        out = run_script(
+            [
+                "SELECT id, score INTO #c FROM null_edges "
+                "WHERE score > 40 ORDER BY score DESC",
+                "SELECT * FROM #c",
+            ],
+            data,
+        )
+        rows = parse_last_result(out)
+        scores = [r["score"] for r in rows]
+        assert scores == sorted(scores, key=int, reverse=True), (
+            f"staged rows lost their ordering: {scores}"
+        )
+    finally:
+        os.unlink(data)
+
+
+def test_into_star_stages_everything():
+    """Control: SELECT * INTO still stages all columns and all matching rows."""
+    data = _data_file()
+    try:
+        out = run_script(
+            ["SELECT * INTO #d FROM null_edges", "SELECT * FROM #d"], data
+        )
+        rows = parse_last_result(out)
+        assert len(rows) == 12
+        assert list(rows[0].keys()) == ["id", "team", "score", "label"]
+    finally:
+        os.unlink(data)
+
+
+def test_cli_limit_with_projection():
+    """P31: --limit with a SELECT list used to return 0 rows under the source's
+    headers, because the limited table was built from the source's columns but
+    the projection's row values."""
+    data = _data_file()
+    try:
+        out = run_query(
+            "SELECT id, score FROM null_edges WHERE score > 40", data, ("--limit", "2")
+        )
+        rows = list(csv.DictReader(StringIO(out)))
+        assert len(rows) == 2, f"expected 2 rows, got {len(rows)}"
+        assert list(rows[0].keys()) == ["id", "score"], (
+            f"expected the projected columns, got {list(rows[0].keys())}"
+        )
+    finally:
+        os.unlink(data)
+
+
+def test_cli_limit_does_not_widen_sql_limit():
+    """Control: the tighter of SQL LIMIT and --limit wins."""
+    data = _data_file()
+    try:
+        out = run_query("SELECT id FROM null_edges LIMIT 2", data, ("--limit", "5"))
+        rows = list(csv.DictReader(StringIO(out)))
+        assert len(rows) == 2, f"SQL LIMIT 2 should win over --limit 5, got {len(rows)}"
+    finally:
+        os.unlink(data)
+
+
+def test_cli_limit_star():
+    """Control: SELECT * with --limit was always correct and must stay so."""
+    data = _data_file()
+    try:
+        out = run_query("SELECT * FROM null_edges", data, ("--limit", "3"))
+        rows = list(csv.DictReader(StringIO(out)))
+        assert len(rows) == 3
+        assert list(rows[0].keys()) == ["id", "team", "score", "label"]
+    finally:
+        os.unlink(data)

--- a/tests/view_materialization_tests.rs
+++ b/tests/view_materialization_tests.rs
@@ -1,0 +1,156 @@
+//! Regression tests for turning a `DataView` back into a `DataTable`
+//! (parity P28 / P31).
+//!
+//! A `DataView` carries three things the source table does not: the WHERE
+//! filter (`visible_rows`), the SELECT projection (`visible_columns`) and the
+//! LIMIT/OFFSET window. Every consumer that materializes a result — staging a
+//! temp table via `SELECT ... INTO`, applying the `--limit` flag — has to
+//! respect all three. Reaching past the view to `source()` silently
+//! reintroduces rows and columns the query excluded.
+//!
+//! `materialize_view` already honoured the filter and the projection; it
+//! iterated `visible_row_indices()`, which is the *pre-limit* set, so a LIMIT
+//! was dropped.
+
+use sql_cli::data::data_view::DataView;
+use sql_cli::data::datatable::{DataColumn, DataRow, DataTable, DataType, DataValue};
+use sql_cli::data::query_engine::QueryEngine;
+use sql_cli::execution::{ExecutionContext, StatementExecutor};
+use sql_cli::sql::recursive_parser::Parser;
+use std::sync::Arc;
+
+/// 5 rows, 3 columns; 3 rows have `score > 40`.
+fn scores_table() -> DataTable {
+    let mut table = DataTable::new("scores");
+    table.add_column(DataColumn::new("id").with_type(DataType::Integer));
+    table.add_column(DataColumn::new("team").with_type(DataType::String));
+    table.add_column(DataColumn::new("score").with_type(DataType::Integer));
+    for (id, team, score) in [
+        (1, "alpha", 50),
+        (2, "alpha", 10),
+        (3, "beta", 70),
+        (4, "beta", 20),
+        (5, "gamma", 90),
+    ] {
+        let _ = table.add_row(DataRow {
+            values: vec![
+                DataValue::Integer(id),
+                DataValue::String(team.to_string()),
+                DataValue::Integer(score),
+            ],
+        });
+    }
+    table
+}
+
+fn view_for(sql: &str) -> DataView {
+    let mut context = ExecutionContext::new(Arc::new(scores_table()));
+    let executor = StatementExecutor::new();
+    let stmt = Parser::new(sql)
+        .parse()
+        .unwrap_or_else(|e| panic!("parse failed for `{sql}`: {e}"));
+    executor
+        .execute(stmt, &mut context)
+        .unwrap_or_else(|e| panic!("exec failed for `{sql}`: {e}"))
+        .dataview
+}
+
+fn materialize(sql: &str) -> DataTable {
+    QueryEngine::new()
+        .materialize_view(view_for(sql))
+        .expect("materialize")
+}
+
+#[test]
+fn materialize_view_honours_the_where_clause() {
+    let table = materialize("SELECT id, score FROM scores WHERE score > 40");
+    assert_eq!(
+        table.row_count(),
+        3,
+        "materializing must not reintroduce filtered-out rows"
+    );
+}
+
+#[test]
+fn materialize_view_honours_the_select_list() {
+    let table = materialize("SELECT id, score FROM scores WHERE score > 40");
+    let names: Vec<_> = table.columns.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["id", "score"],
+        "materializing must keep the projection, not the source's columns"
+    );
+}
+
+#[test]
+fn materialize_view_honours_limit() {
+    // The bug: `visible_row_indices()` is the pre-limit set, so all 5 rows
+    // were copied.
+    let table = materialize("SELECT id FROM scores LIMIT 2");
+    assert_eq!(table.row_count(), 2, "LIMIT must survive materialization");
+}
+
+#[test]
+fn materialize_view_honours_limit_after_a_filter() {
+    let table = materialize("SELECT id FROM scores WHERE score > 40 LIMIT 2");
+    assert_eq!(table.row_count(), 2);
+}
+
+#[test]
+fn materialize_view_keeps_order_by() {
+    let table = materialize("SELECT id, score FROM scores ORDER BY score DESC");
+    let scores: Vec<i64> = (0..table.row_count())
+        .map(|i| match &table.rows[i].values[1] {
+            DataValue::Integer(n) => *n,
+            other => panic!("expected an integer score, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(scores, vec![90, 70, 50, 20, 10]);
+}
+
+#[test]
+fn materialize_view_of_an_unrestricted_query_is_the_whole_table() {
+    // Control: the case that was always correct must stay correct.
+    let table = materialize("SELECT * FROM scores");
+    assert_eq!(table.row_count(), 5);
+    assert_eq!(table.columns.len(), 3);
+}
+
+#[test]
+fn windowed_row_indices_applies_offset_and_limit() {
+    let view = DataView::new(Arc::new(scores_table())).with_limit(2, 1);
+    assert_eq!(view.visible_row_indices(), &[0, 1, 2, 3, 4]);
+    assert_eq!(
+        view.windowed_row_indices(),
+        &[1, 2],
+        "the windowed set is what the consumer actually sees"
+    );
+    assert_eq!(view.row_count(), view.windowed_row_indices().len());
+}
+
+#[test]
+fn windowed_row_indices_clamps_an_oversized_window() {
+    let view = DataView::new(Arc::new(scores_table())).with_limit(100, 3);
+    assert_eq!(view.windowed_row_indices(), &[3, 4]);
+
+    let past_the_end = DataView::new(Arc::new(scores_table())).with_limit(2, 99);
+    assert!(past_the_end.windowed_row_indices().is_empty());
+}
+
+#[test]
+fn with_max_rows_takes_the_tighter_window() {
+    let base = DataView::new(Arc::new(scores_table()));
+    assert_eq!(base.clone().with_max_rows(3).row_count(), 3);
+
+    // A wider display limit must not widen an existing SQL LIMIT.
+    let limited = DataView::new(Arc::new(scores_table())).with_limit(2, 0);
+    assert_eq!(limited.with_max_rows(5).row_count(), 2);
+}
+
+#[test]
+fn with_max_rows_preserves_the_offset() {
+    let view = DataView::new(Arc::new(scores_table()))
+        .with_limit(4, 1)
+        .with_max_rows(2);
+    assert_eq!(view.windowed_row_indices(), &[1, 2]);
+}


### PR DESCRIPTION
Closes parity **P28** and **P31**; files and closes **R9** in the refactoring log.

## P28 — `SELECT ... INTO #tmp` staged the whole source table

Filed as "the `WHERE` is ignored". It was wider than that: the staged table was
the **entire source table** — every row, every column, ordering lost.

```sql
SELECT COUNT(*) FROM null_edges WHERE score IS NOT NULL;            -- 8  correct
SELECT id, score INTO #a FROM null_edges WHERE score IS NOT NULL;
SELECT * FROM #a;   -- before: 12 rows, all 6 source columns
                    -- after:   8 rows, just id + score
```

P28 was diagnosed with `COUNT(*)`, which could only ever report a row count —
worth recording, because the entry describes the symptom someone looked for, not
necessarily the defect.

**Root cause.** A `DataView` carries three things the source table does not: the
`WHERE` filter, the `SELECT` projection, and the `LIMIT`/`OFFSET` window. The
script path (`non_interactive.rs`) stored `final_view.source_arc()` — the
backing table, reaching past the view entirely. `QueryEngine::materialize_view`
is the shared helper that does this correctly, and **two other call sites
already used it**; the path that actually runs `INTO` did not.

**A second defect underneath, in the helper itself.** It iterated
`visible_row_indices()`, documented as the *pre*-limit set, so
`SELECT id INTO #a FROM t LIMIT 3` staged all 12 rows — through the two callers
that were otherwise correct. Added `DataView::windowed_row_indices()`, the
post-limit set that `row_count()` actually counts. The pre-limit accessor stays
for callers that mean it, with the trap named in its doc comment.

## P31 — `--limit` returned zero rows for any query with a `SELECT` list

Found by the sweep P28's own entry prescribed ("check whether any other consumer
of a query result takes the same route").

```
$ sql-cli data/null_edges.csv -q "SELECT id, score FROM null_edges" --limit 3 -o csv
id,team,score,label,bonus,partner_id        <-- the source's columns
                                            <-- and no rows at all
```

`limit_results` built the table from `source().columns` — all of them — but
filled it with `get_row(i)`, which returns only the **projected** values. Every
row then failed the column-count check inside `add_row`, whose `Result` was
discarded with `let _ =`. Zero rows under the wrong headers, reported as a
successful query. `SELECT *` was fine, which is exactly why it survived: the
flag works on the shape you reach for when trying it out.

It now goes through `materialize_view` over a view narrowed by
`DataView::with_max_rows`, which takes the tighter of the SQL `LIMIT` and the CLI
flag and leaves any `OFFSET` alone — preserving the old `row_count().min(limit)`
intent.

## R9 — one shape, two silent wrong answers

Four places needed to collapse a `DataView` back into a `DataTable`. There was
one correct helper and two hand-rolled copies that each dropped a *different*
part of the view. `materialize_view` is now the only implementation.

Generalisable lesson, recorded in the log: **an accessor whose name states the
common case and whose doc states the exception will be misused.**
`visible_row_indices()` was the obvious-looking call at all four sites and the
wrong one at three of them.

## Tests

- `tests/python_tests/test_temp_table_staging.py` — 9 end-to-end cases through
  the real binary, since the defect lived in the script path, not the engine.
  **7 fail against the unfixed binary** (verified by stashing the fix and
  rebuilding); the 2 that pass either way are labelled controls.
- `tests/view_materialization_tests.rs` — 10 env-free cases at engine level.
  Neither bug can have a corpus case: `INTO #tmp` is our own extension and
  `--limit` is a CLI flag, so the reference engine has no equivalent.

## Verification

- `cargo test` green (688 + 433), `cargo fmt --check` clean, no new clippy output
  on the touched files.
- **Parity unchanged at 125 AGREE / 159 cases** — no regression.
- **All FORMAL examples pass.** Not silence-by-luck: the three examples using
  `INTO` are all `SELECT *` with no `WHERE` or `LIMIT`, so none of them had
  captured the bug — unlike the four expectations that had captured P21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
