### PR TITLE
fix(parser): let DATETIME() take expressions, not just literals

### DIFF
--- a/examples/expectations/presidents.json
+++ b/examples/expectations/presidents.json
@@ -450,6 +450,127 @@
   ],
   [
     {
+      "BirthDate": "1908-08-27 00:00:00.000",
+      "BornOn": "Thursday",
+      "LeapYear": true,
+      "Name": "Lyndon B. Johnson",
+      "Qtr": 3
+    },
+    {
+      "BirthDate": "1911-02-06 00:00:00.000",
+      "BornOn": "Monday",
+      "LeapYear": false,
+      "Name": "Ronald Reagan",
+      "Qtr": 1
+    },
+    {
+      "BirthDate": "1913-01-09 00:00:00.000",
+      "BornOn": "Thursday",
+      "LeapYear": false,
+      "Name": "Richard M. Nixon",
+      "Qtr": 1
+    },
+    {
+      "BirthDate": "1913-07-14 00:00:00.000",
+      "BornOn": "Monday",
+      "LeapYear": false,
+      "Name": "Gerald R. Ford",
+      "Qtr": 3
+    },
+    {
+      "BirthDate": "1917-05-29 00:00:00.000",
+      "BornOn": "Tuesday",
+      "LeapYear": false,
+      "Name": "John Kennedy",
+      "Qtr": 2
+    },
+    {
+      "BirthDate": "1924-06-12 00:00:00.000",
+      "BornOn": "Thursday",
+      "LeapYear": true,
+      "Name": "George H. W. Bush",
+      "Qtr": 2
+    },
+    {
+      "BirthDate": "1924-10-01 00:00:00.000",
+      "BornOn": "Wednesday",
+      "LeapYear": true,
+      "Name": "Jimmy Carter",
+      "Qtr": 4
+    },
+    {
+      "BirthDate": "1946-06-06 00:00:00.000",
+      "BornOn": "Thursday",
+      "LeapYear": false,
+      "Name": "George W. Bush",
+      "Qtr": 2
+    },
+    {
+      "BirthDate": "1946-06-14 00:00:00.000",
+      "BornOn": "Friday",
+      "LeapYear": false,
+      "Name": "Donald Trump",
+      "Qtr": 2
+    },
+    {
+      "BirthDate": "1946-08-19 00:00:00.000",
+      "BornOn": "Monday",
+      "LeapYear": false,
+      "Name": "William J. Clinton",
+      "Qtr": 3
+    },
+    {
+      "BirthDate": "1961-08-04 00:00:00.000",
+      "BornOn": "Friday",
+      "LeapYear": false,
+      "Name": "Barack Hussein Obama",
+      "Qtr": 3
+    }
+  ],
+  [
+    {
+      "BirthDate": "1856-12-28 00:00:00.000",
+      "Height": 71,
+      "Name": "Woodrow Wilson"
+    },
+    {
+      "BirthDate": "1858-10-27 00:00:00.000",
+      "Height": 70,
+      "Name": "Theodore Roosevelt"
+    },
+    {
+      "BirthDate": "1872-07-04 00:00:00.000",
+      "Height": 70,
+      "Name": "Calvin Coolidge"
+    },
+    {
+      "BirthDate": "1874-08-10 00:00:00.000",
+      "Height": 71,
+      "Name": "Herbert Hoover"
+    },
+    {
+      "BirthDate": "1911-02-06 00:00:00.000",
+      "Height": 74,
+      "Name": "Ronald Reagan"
+    },
+    {
+      "BirthDate": "1917-05-29 00:00:00.000",
+      "Height": 72,
+      "Name": "John Kennedy"
+    },
+    {
+      "BirthDate": "1924-10-01 00:00:00.000",
+      "Height": 69,
+      "Name": "Jimmy Carter"
+    },
+    {
+      "BirthDate": "1946-06-14 00:00:00.000",
+      "Height": 75,
+      "Name": "Donald Trump"
+    }
+  ],
+  [
+    {
       "AvgHeight": 74.25,
       "Greatness": 5,
       "Presidents": 4

--- a/examples/presidents.sql
+++ b/examples/presidents.sql
@@ -111,6 +111,38 @@ WHERE r.Greatness.Trim() <> 'NA'
 ORDER BY r.Greatness DESC, b.Name;
 GO
 
+-- === Building a real date out of three columns ===
+-- The file stores the birthday split across Day/Month/Year. DATETIME() takes
+-- expressions, so those columns compose into an actual date rather than a
+-- string, and the rest of the date functions work on the result.
+WITH
+    birthdays AS (SELECT Name, Year, Month, Day FROM read_csv('data/president_birthdays.csv'))
+SELECT
+    Name,
+    DATETIME(Year, Month, Day) AS BirthDate,
+    DAYNAME(DATETIME(Year, Month, Day)) AS BornOn,
+    QUARTER(DATETIME(Year, Month, Day)) AS Qtr,
+    ISLEAPYEAR(Year) AS LeapYear
+FROM birthdays
+WHERE Year > 1900
+ORDER BY DATETIME(Year, Month, Day);
+GO
+
+-- === Dates compare as dates ===
+-- Not as strings: the comparison below is against a constructed date literal.
+WITH
+    birthdays AS (SELECT Name, Year, Month, Day FROM read_csv('data/president_birthdays.csv')),
+    heights   AS (SELECT Name, "Height (inches)" AS Height FROM read_csv('data/president_heights.csv'))
+SELECT
+    b.Name,
+    DATETIME(b.Year, b.Month, b.Day) AS BirthDate,
+    h.Height
+FROM birthdays b
+JOIN heights h ON b.Name = h.Name
+WHERE DATETIME(b.Year, b.Month, b.Day) > DATETIME(1850, 1, 1)
+ORDER BY BirthDate;
+GO
+
 -- === Does height predict greatness? ===
 -- Average height per greatness score, over the presidents who carry both.
 WITH

--- a/src/sql/parser/expressions/primary.rs
+++ b/src/sql/parser/expressions/primary.rs
@@ -403,7 +403,26 @@ where
     result
 }
 
-/// Parse DateTime constructor
+/// Parse `DATETIME(...)`.
+///
+/// `DATETIME` is lexed as a keyword rather than an identifier, because
+/// `CAST(x AS DATETIME)` needs that type spelling reserved. The cost is that it
+/// never reaches the generic function-call arm of `parse_primary`, so it used to
+/// be assembled here out of `NumberLiteral` tokens straight into a
+/// `DateTimeConstructor` node. That made the components *parse-time constants*:
+/// `DATETIME(2024, 1, 15)` worked, but `DATETIME(Year, Month, Day)` failed with
+/// "Expected year in DateTime constructor" before evaluation ever began, and no
+/// amount of casting helped.
+///
+/// The registry already carries a `DATETIME` function taking runtime values
+/// (`functions::date_time::DateTimeConstructor`, 3-7 args, NULL-propagating), so
+/// the fix is simply to stop intercepting: parse an ordinary argument list and
+/// let the registry evaluate it. Both paths format as `%Y-%m-%d %H:%M:%S%.3f`,
+/// so literal calls are unaffected.
+///
+/// The no-argument `DATETIME()` (today at midnight) keeps its own node — the
+/// registry signature requires at least three arguments, so there is nothing to
+/// delegate to.
 fn parse_datetime_constructor<P>(parser: &mut P) -> Result<SqlExpression, String>
 where
     P: ParsePrimary + ExpressionParser + ?Sized,
@@ -411,7 +430,7 @@ where
     ExpressionParser::advance(parser); // consume DateTime
     ExpressionParser::consume(parser, Token::LeftParen)?;
 
-    // Check if empty parentheses for DateTime() - today's date
+    // DATETIME() with no arguments is today's date
     if matches!(ExpressionParser::current_token(parser), Token::RightParen) {
         ExpressionParser::advance(parser); // consume )
         debug!("DateTime() - today's date");
@@ -422,78 +441,18 @@ where
         });
     }
 
-    // Parse year
-    let year = if let Token::NumberLiteral(n) = ExpressionParser::current_token(parser) {
-        n.parse::<i32>().map_err(|_| "Invalid year")?
-    } else {
-        return Err("Expected year in DateTime constructor".to_string());
-    };
-    ExpressionParser::advance(parser);
-    ExpressionParser::consume(parser, Token::Comma)?;
-
-    // Parse month
-    let month = if let Token::NumberLiteral(n) = ExpressionParser::current_token(parser) {
-        n.parse::<u32>().map_err(|_| "Invalid month")?
-    } else {
-        return Err("Expected month in DateTime constructor".to_string());
-    };
-    ExpressionParser::advance(parser);
-    ExpressionParser::consume(parser, Token::Comma)?;
-
-    // Parse day
-    let day = if let Token::NumberLiteral(n) = ExpressionParser::current_token(parser) {
-        n.parse::<u32>().map_err(|_| "Invalid day")?
-    } else {
-        return Err("Expected day in DateTime constructor".to_string());
-    };
-    ExpressionParser::advance(parser);
-
-    // Check for optional time components
-    let mut hour = None;
-    let mut minute = None;
-    let mut second = None;
-
-    if matches!(ExpressionParser::current_token(parser), Token::Comma) {
-        ExpressionParser::advance(parser); // consume comma
-
-        // Parse hour
-        if let Token::NumberLiteral(n) = ExpressionParser::current_token(parser) {
-            hour = Some(n.parse::<u32>().map_err(|_| "Invalid hour")?);
-            ExpressionParser::advance(parser);
-
-            // Check for minute
-            if matches!(ExpressionParser::current_token(parser), Token::Comma) {
-                ExpressionParser::advance(parser); // consume comma
-
-                if let Token::NumberLiteral(n) = ExpressionParser::current_token(parser) {
-                    minute = Some(n.parse::<u32>().map_err(|_| "Invalid minute")?);
-                    ExpressionParser::advance(parser);
-
-                    // Check for second
-                    if matches!(ExpressionParser::current_token(parser), Token::Comma) {
-                        ExpressionParser::advance(parser); // consume comma
-
-                        if let Token::NumberLiteral(n) = ExpressionParser::current_token(parser) {
-                            second = Some(n.parse::<u32>().map_err(|_| "Invalid second")?);
-                            ExpressionParser::advance(parser);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
+    let (args, _distinct) = parser.parse_function_args()?;
     ExpressionParser::consume(parser, Token::RightParen)?;
 
-    debug!(year = year, month = month, day = day, hour = ?hour, minute = ?minute, second = ?second, "DateTime constructor parsed");
+    debug!(
+        arg_count = args.len(),
+        "DATETIME parsed as registry function call"
+    );
 
-    Ok(SqlExpression::DateTimeConstructor {
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
+    Ok(SqlExpression::FunctionCall {
+        name: "DATETIME".to_string(),
+        args,
+        distinct: false,
     })
 }
 

--- a/tests/datetime_completion.rs
+++ b/tests/datetime_completion.rs
@@ -39,21 +39,69 @@ fn test_datetime_parsing() {
     let where_clause = stmt.where_clause.unwrap();
     assert_eq!(where_clause.conditions.len(), 1);
 
-    // Verify the DateTime constructor was parsed correctly
+    // DateTime(...) lowers to an ordinary call on the registry's DATETIME
+    // function, so its arguments are expressions rather than parse-time
+    // constants. That is what lets DateTime(Year, Month, Day) work at all.
     use sql_cli::sql::recursive_parser::SqlExpression;
     if let SqlExpression::BinaryOp { left, op, right } = &where_clause.conditions[0].expr {
         assert_eq!(op, ">");
         assert!(matches!(left.as_ref(), SqlExpression::Column(col) if col.name == "createdDate"));
-        assert!(matches!(
-            right.as_ref(),
-            SqlExpression::DateTimeConstructor {
-                year: 2025,
-                month: 10,
-                day: 20,
-                ..
+        match right.as_ref() {
+            SqlExpression::FunctionCall { name, args, .. } => {
+                assert_eq!(name, "DATETIME");
+                assert_eq!(args.len(), 3);
+                assert!(matches!(&args[0], SqlExpression::NumberLiteral(n) if n == "2025"));
+                assert!(matches!(&args[1], SqlExpression::NumberLiteral(n) if n == "10"));
+                assert!(matches!(&args[2], SqlExpression::NumberLiteral(n) if n == "20"));
             }
-        ));
+            other => panic!("Expected DATETIME function call, got {other:?}"),
+        }
     } else {
         panic!("Expected BinaryOp with DateTime constructor");
+    }
+}
+
+#[test]
+fn test_datetime_accepts_column_arguments() {
+    use sql_cli::sql::recursive_parser::{Parser, SqlExpression};
+
+    // The whole point of the change: components that are columns, not literals.
+    let mut parser = Parser::new("SELECT DateTime(Year, Month, Day) AS d FROM birthdays");
+    let stmt = parser.parse().unwrap();
+
+    let SqlExpression::FunctionCall { name, args, .. } = extract_first_expression(&stmt) else {
+        panic!("Expected DATETIME function call");
+    };
+    assert_eq!(name, "DATETIME");
+    assert_eq!(args.len(), 3);
+    for (arg, expected) in args.iter().zip(["Year", "Month", "Day"]) {
+        assert!(
+            matches!(arg, SqlExpression::Column(col) if col.name == expected),
+            "expected column {expected}, got {arg:?}"
+        );
+    }
+}
+
+#[test]
+fn test_datetime_no_args_is_still_today() {
+    use sql_cli::sql::recursive_parser::{Parser, SqlExpression};
+
+    // The registry signature needs 3-7 args, so the bare form keeps its own node.
+    let mut parser = Parser::new("SELECT DateTime() AS d FROM t");
+    let stmt = parser.parse().unwrap();
+
+    assert!(matches!(
+        extract_first_expression(&stmt),
+        SqlExpression::DateTimeToday { .. }
+    ));
+}
+
+fn extract_first_expression(
+    stmt: &sql_cli::sql::recursive_parser::SelectStatement,
+) -> &sql_cli::sql::recursive_parser::SqlExpression {
+    use sql_cli::sql::recursive_parser::SelectItem;
+    match &stmt.select_items[0] {
+        SelectItem::Expression { expr, .. } => expr,
+        other => panic!("Expected an expression select item, got {other:?}"),
     }
 }

--- a/tests/python_tests/test_datetime_constructor.py
+++ b/tests/python_tests/test_datetime_constructor.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Test the DATETIME(year, month, day, ...) constructor.
+
+DATETIME is lexed as a keyword (CAST(x AS DATETIME) needs the spelling
+reserved), so it never reaches the parser's generic function-call arm. It used
+to be assembled from NumberLiteral tokens into a parse-time-constant AST node,
+which meant DATETIME(Year, Month, Day) failed to parse at all. It now lowers to
+an ordinary call on the registry's DATETIME function, so its arguments are
+expressions. These tests pin both halves: the literal forms must not have
+changed, and the expression forms must work.
+"""
+
+import csv
+import subprocess
+import sys
+from io import StringIO
+from pathlib import Path
+
+
+def run_query(query, data_file=None):
+    """Execute a query and return the results as a list of dicts."""
+    base_dir = Path(__file__).parent.parent.parent
+    suffix = ".exe" if sys.platform == "win32" else ""
+    sql_cli = base_dir / "target" / "release" / f"sql-cli{suffix}"
+
+    if not sql_cli.exists():
+        raise FileNotFoundError(f"sql-cli not found at {sql_cli}")
+
+    cmd = [str(sql_cli)]
+
+    if data_file:
+        data_path = base_dir / "data" / data_file
+        if not data_path.exists():
+            raise FileNotFoundError(f"Data file not found: {data_path}")
+        cmd.append(str(data_path))
+
+    cmd.extend(["-q", query, "-o", "csv"])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        print(f"Error running query: {result.stderr}")
+        return None
+
+    reader = csv.DictReader(StringIO(result.stdout))
+    return list(reader)
+
+
+# ---- literal forms: behaviour must be unchanged ----
+
+def test_datetime_from_literals():
+    """DATETIME with number literals still builds the same date."""
+    results = run_query("SELECT DATETIME(1732, 2, 22) AS d")
+
+    assert results is not None
+    assert results[0]['d'] == '1732-02-22 00:00:00.000'
+    print("✓ test_datetime_from_literals passed")
+
+
+def test_datetime_with_time_components():
+    """The optional hour/minute/second arguments still apply."""
+    results = run_query("SELECT DATETIME(2024, 1, 15, 14, 30, 0) AS d")
+
+    assert results is not None
+    assert results[0]['d'] == '2024-01-15 14:30:00.000'
+    print("✓ test_datetime_with_time_components passed")
+
+
+def test_datetime_no_args_is_today():
+    """DATETIME() keeps its own AST node - the registry needs 3+ args."""
+    results = run_query("SELECT DATETIME() AS d")
+
+    assert results is not None
+    # Today at midnight; assert the shape rather than a moving value.
+    assert results[0]['d'].endswith(' 00:00:00.000')
+    assert len(results[0]['d']) == len('2026-08-16 00:00:00.000')
+    print("✓ test_datetime_no_args_is_today passed")
+
+
+# ---- expression forms: what the change unlocks ----
+
+def test_datetime_from_columns():
+    """The reason for the change: build a date out of three columns."""
+    query = ("SELECT Name, DATETIME(Year, Month, Day) AS BirthDate "
+             "FROM president_birthdays WHERE Year = 1732")
+    results = run_query(query, "president_birthdays.csv")
+
+    assert results is not None
+    assert len(results) == 1
+    assert results[0]['Name'] == 'George Washington'
+    assert results[0]['BirthDate'] == '1732-02-22 00:00:00.000'
+    print("✓ test_datetime_from_columns passed")
+
+
+def test_datetime_from_arithmetic():
+    """Arguments are full expressions, not just column references."""
+    query = ("SELECT DATETIME(Year + 100, Month, Day) AS d "
+             "FROM president_birthdays WHERE Year = 1732")
+    results = run_query(query, "president_birthdays.csv")
+
+    assert results is not None
+    assert results[0]['d'] == '1832-02-22 00:00:00.000'
+    print("✓ test_datetime_from_arithmetic passed")
+
+
+def test_datetime_with_cast_argument():
+    """A CAST inside the argument list parses (it used to fail outright)."""
+    query = ("SELECT DATETIME(CAST(Year AS INTEGER), Month, Day) AS d "
+             "FROM president_birthdays WHERE Year = 1732")
+    results = run_query(query, "president_birthdays.csv")
+
+    assert results is not None
+    assert results[0]['d'] == '1732-02-22 00:00:00.000'
+    print("✓ test_datetime_with_cast_argument passed")
+
+
+def test_datetime_in_where_clause():
+    """Comparing a constructed date against a literal one."""
+    query = ("SELECT Name FROM president_birthdays "
+             "WHERE DATETIME(Year, Month, Day) > DATETIME(1950, 1, 1)")
+    results = run_query(query, "president_birthdays.csv")
+
+    assert results is not None
+    assert [row['Name'] for row in results] == ['Barack Hussein Obama']
+    print("✓ test_datetime_in_where_clause passed")
+
+
+def test_datetime_feeds_date_functions():
+    """A constructed date is a real date, so date functions accept it."""
+    query = ("SELECT DAYNAME(DATETIME(Year, Month, Day)) AS BornOn, "
+             "QUARTER(DATETIME(Year, Month, Day)) AS Qtr "
+             "FROM president_birthdays WHERE Year = 1732")
+    results = run_query(query, "president_birthdays.csv")
+
+    assert results is not None
+    assert results[0]['BornOn'] == 'Friday'
+    assert results[0]['Qtr'] == '1'
+    print("✓ test_datetime_feeds_date_functions passed")
+
+
+def test_datetime_propagates_null():
+    """A NULL component yields NULL rather than an error.
+
+    The extra tag column keeps the CSV row from being entirely blank, which
+    csv.DictReader would otherwise skip.
+    """
+    query = "SELECT 'x' AS tag, DATETIME(NULL, 1, 15) AS d"
+    results = run_query(query)
+
+    assert results is not None
+    assert len(results) == 1
+    assert results[0]['tag'] == 'x'
+    assert results[0]['d'] == ''
+    print("✓ test_datetime_propagates_null passed")
+
+
+def test_cast_as_datetime_still_parses():
+    """The keyword is still usable as a CAST target type."""
+    results = run_query("SELECT CAST('2024-01-15' AS DATETIME) AS d")
+
+    assert results is not None
+    assert results[0]['d'].startswith('2024-01-15')
+    print("✓ test_cast_as_datetime_still_parses passed")
+
+
+if __name__ == "__main__":
+    test_datetime_from_literals()
+    test_datetime_with_time_components()
+    test_datetime_no_args_is_today()
+    test_datetime_from_columns()
+    test_datetime_from_arithmetic()
+    test_datetime_with_cast_argument()
+    test_datetime_in_where_clause()
+    test_datetime_feeds_date_functions()
+    test_datetime_propagates_null()
+    test_cast_as_datetime_still_parses()
+    print("\nAll DATETIME constructor tests passed!")


### PR DESCRIPTION
## The bug

`data/president_birthdays.csv` splits the birthday across `Day`/`Month`/`Year`, so the obvious thing to write is:

```sql
SELECT Name, DATETIME(Year, Month, Day) AS BirthDate FROM president_birthdays
```

which failed with `Parse error: Expected year in DateTime constructor`. Casting didn't help — the failure was at parse time, before any evaluation.

`DATETIME` is lexed as a keyword rather than an identifier, because `CAST(x AS DATETIME)` needs that type spelling reserved. The cost is that it never reached the generic function-call arm of `parse_primary`, so it was assembled by hand out of `NumberLiteral` tokens (`primary.rs:426-449`) straight into a `DateTimeConstructor` AST node holding `i32`/`u32` components:

```rust
let year = if let Token::NumberLiteral(n) = ExpressionParser::current_token(parser) {
    n.parse::<i32>().map_err(|_| "Invalid year")?
} else {
    return Err("Expected year in DateTime constructor".to_string());
};
```

The components could only ever be parse-time constants.

## The fix

The registry **already** carried a `DATETIME` function taking runtime `DataValue`s — `functions::date_time::DateTimeConstructor`, `ArgCount::Range(3, 7)`, NULL-propagating, registered at `date_time.rs:1437`. It was fully capable of handling column arguments. The parser simply never let it see them, which is the *"Function Registry: ALL functions go through the registry — no special cases in parser/evaluator"* rule in CLAUDE.md being violated in both directions at once.

So: stop intercepting. Parse an ordinary argument list and emit a `FunctionCall` for the registry to evaluate. Both paths format as `%Y-%m-%d %H:%M:%S%.3f`, so literal calls are byte-identical. The no-argument `DATETIME()` keeps its own node, since the registry signature requires at least three arguments and there's nothing to delegate to.

## What now works

| Form | Before | After |
|---|---|---|
| `DATETIME(1732, 2, 22)` | `1732-02-22 00:00:00.000` | unchanged |
| `DATETIME(2024, 1, 15, 14, 30, 0)` | `2024-01-15 14:30:00.000` | unchanged |
| `DATETIME()` | today at midnight | unchanged |
| `CAST(x AS DATETIME)` | works | unchanged |
| `DATETIME(Year, Month, Day)` | **parse error** | `1732-02-22 00:00:00.000` |
| `DATETIME(Year + 100, Month, Day)` | **parse error** | `1832-02-22 00:00:00.000` |
| `DATETIME(CAST(Year AS INTEGER), Month, Day)` | **parse error** | works |
| `WHERE DATETIME(Year, Month, Day) > DATETIME(1950,1,1)` | **parse error** | works |
| `DAYNAME(DATETIME(Year, Month, Day))` | **parse error** | `Friday` |

Invalid dates still error cleanly (`Invalid date: 2024-2-30`), and a NULL component yields NULL rather than failing.

## Testing

- **`tests/datetime_completion.rs`** — `test_datetime_parsing` asserted the old `DateTimeConstructor` AST shape, so it now checks the `FunctionCall` lowering. Added `test_datetime_accepts_column_arguments` and `test_datetime_no_args_is_still_today`.
- **`tests/python_tests/test_datetime_constructor.py`** — new, 10 cases, per the "always add Python tests after parser changes" convention. Pins both halves: the literal forms must not have changed, and the expression forms must work.
- **`examples/presidents.sql`** — two new queries building real dates from the three columns and comparing dates as dates; FORMAL expectation re-captured.

Suite status:
- `cargo test` — 697 + 435 + 1 pass (435 is up from 433: the two new integration tests)
- Python — 7 failed / **527** passed / 16 skipped; the 7 are the pre-existing Windows `.exe`-suffix baseline, and 527 is up from 517 by exactly the 10 new tests
- Examples — "All FORMAL tests passed!"
- `cargo fmt` + `cargo clippy` clean

## Left alone

`src/sql/where_parser.rs:112` has its own `Token::DateTime` branch with the same literals-only limitation. It can't be fixed the same way — `WhereValue` is a *value* enum that cannot hold a column reference — and its only caller is `csv_datasource`, which no live CLI or TUI path reaches.

The `SqlExpression::DateTimeConstructor` AST variant is now unreachable from the parser but still referenced by the evaluators and formatters. Removing it touches eight files, so it's left as a separate cleanup for the R-numbered log rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
