### PR TITLE
refactor(engine): add Trilean, the SQL three-valued truth type (R10 slice 1a)

### DIFF
--- a/docs/ENGINE_REFACTORING.md
+++ b/docs/ENGINE_REFACTORING.md
@@ -318,6 +318,40 @@ feature work**, and so we can tell the difference between "this is awkward" and
   obvious-looking call at all four sites and the wrong one at three of them —
   the same failure mode as [R3](#r3)'s catch-all arms, one layer down.
 
+### R10 — Predicate evaluation has no way to say UNKNOWN
+- **Status:** 🟡 IN PROGRESS — slice 1a done 2026-08-22; 1b/1c outstanding
+- **Where:** `src/data/recursive_where_evaluator.rs` (9 `Result<bool>`
+  signatures, 14 match arms), two construction sites in
+  `src/data/query_engine.rs`, and one semantic boundary — the
+  `if result { filtered_rows.push(row_idx) }` row filter in the same file.
+- **Observed:** SQL predicates are evaluated in *three-valued* logic, but the
+  evaluator returns `Result<bool>`, so UNKNOWN has no representation. `NOT` is
+  `Ok(!inner)` and `NOT IN` is `Ok(!in_result)`, which turns UNKNOWN into TRUE
+  and admits rows that must not pass. This is the mechanism behind
+  [P18](SQL_PARITY.md#p18) and [P19](SQL_PARITY.md#p19) — a **type** problem
+  before it is a semantics problem, which is why patching per-operator has not
+  worked and should not be attempted.
+- **Slicing** (agreed 2026-08-08; only the last slice changes results):
+  - **1a — done 2026-08-22.** `src/data/trilean.rs`: the `Trilean` type, the
+    `AND`/`OR`/`NOT` truth tables, and `is_true()` as the *only* sanctioned
+    collapse back to `bool`. 13 unit tests assert the tables cell by cell rather
+    than deriving them, plus the algebraic laws the evaluator's rewrites lean on
+    (double negation, De Morgan, associativity) and the one that **fails** in
+    3VL — excluded middle, `x OR NOT x` is UNKNOWN when `x` is. Nothing is
+    wired; the engine does not reference it yet.
+  - **1b — outstanding.** Convert the evaluator to `Trilean` internally and
+    collapse `Unknown → false` at the single boundary. A no-op *by
+    construction*: `boolean_subset_matches_two_valued_logic` pins that `Trilean`
+    equals `bool` over TRUE/FALSE, and the acceptance test is that parity stays
+    at **exactly** its current AGREE count.
+  - **1c — outstanding.** Flip the semantics (`= NULL`, `IN` with a NULL in the
+    list, `NOT IN`, `NOT`). This one changes results and will churn FORMAL
+    example expectations; verify each diff against DuckDB before re-capturing.
+- **Why the split is worth it:** 1b is a large mechanical diff with zero
+  behaviour change, and 1c is a small diff with all of it. Landing them together
+  would mean reviewing a semantic change buried in 200 lines of signature
+  churn — and leave no checkpoint to bisect against if parity moves.
+
 ---
 
 ## Sequencing
@@ -339,6 +373,7 @@ R1 FROM migration ── independent; deferred (larger than P3)
 R4 fixtures ──────── adopt opportunistically, per transformer touched
 R5 dead code ─────── opportunistic
 R8 legacy WHERE ──── independent; stage 2 is self-contained, do it in a lull
+R10 Trilean ──────── 1a landed; 1b (no-op) then 1c (closes P18/P19)
 ```
 
 **A note on ordering, from the P18/P19 work being next.** The WHERE evaluator
@@ -367,3 +402,4 @@ AGREE count — which makes it safe to land well before the semantics change.
 | 2026-08-02 | Corpus tiers 08 (ordering), 09 (window/QUALIFY), 10 (aggregate/NULL) added; P13–P15 filed. 83 → 96 cases | — |
 | 2026-08-08 | R8 filed and stage 1 done: 830 lines of zero-caller legacy WHERE deleted (`where_clause_converter`, `where_evaluator`, `simple_where`) plus `DebugWidget`'s dead WHERE-AST code. No behaviour change | #47 |
 | 2026-08-16 | R9 filed and done: view→table materialization consolidated on `materialize_view`; `DataView` gains `windowed_row_indices`/`with_max_rows`. Closes parity P28 and P31 | — |
+| 2026-08-22 | R10 filed; slice 1a landed: `data::trilean` with the 3VL truth tables and 13 unit tests. Unwired — no behaviour change, parity unmoved at 125/159 | — |

--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -80,7 +80,7 @@ Suggested fix order, by silent blast radius:
 | ~~3~~ | ~~[P30](#p30) `cond AND col IN (list)` returns 0 rows~~ | ✅ **Fixed 2026-08-08** |
 | ~~5~~ | ~~[P29](#p29) boolean operator after `IN (...)`~~ | ✅ **Fixed 2026-08-08** — same bug as P30, one change closed both |
 | ~~4~~ | ~~[P28](#p28) `INTO #tmp` stages unfiltered rows~~ | ✅ **Fixed 2026-08-16** — turned out to stage the *whole source table*, and the sweep it prescribed found [P31](#p31) |
-| **7** | **[P18](#p18)/[P19](#p19) three-valued logic** | Promoted: silent, P18 produces *extra* rows, and it now blocks two more corpus cases that the P29 fix uncovered |
+| **7** | **[P18](#p18)/[P19](#p19) three-valued logic** | Promoted: silent, P18 produces *extra* rows, and it now blocks two more corpus cases that the P29 fix uncovered. **Started 2026-08-22** — the `Trilean` type is in ([R10](ENGINE_REFACTORING.md#r10) slice 1a); next is wiring it as a provable no-op, then flipping the semantics |
 | 8 | [P24](#p24) `RANGE` treated as `ROWS` | Silent, hits the common `SUM(x) OVER (ORDER BY y)` running-total form |
 | 9 | [P14](#p14), [P16](#p16), [P17](#p17), [P20](#p20), [P23](#p23), P13 stage 2 | Smaller, self-contained, decisions already taken |
 | 10 | [P22](#p22), [P25](#p25), [P26](#p26), [P15](#p15) | Hard errors — visible, so less urgent than any of the above |
@@ -699,7 +699,12 @@ annotation be removed.
   the two ASC cases flip DIFFER → AGREE and their `expect` should be dropped.
 
 ### P18 — `= NULL` matches NULL rows instead of yielding UNKNOWN
-- **Status:** 🔴 OPEN — **second site found 2026-08-08, see below**
+- **Status:** 🟡 IN PROGRESS — groundwork started 2026-08-22; **second site
+  found 2026-08-08, see below**
+- **Groundwork:** the fix is gated on the evaluator being able to *represent*
+  UNKNOWN at all — see [R10](ENGINE_REFACTORING.md#r10) for the slicing.
+  `src/data/trilean.rs` (the type and its truth tables) landed 2026-08-22,
+  unwired; the semantics flip is slice 1c and closes this entry with P19.
 - **Corpus:** `10_aggregate_nulls.toml :: where_equals_null` (DIFFER).
   Baseline: `where_is_null` (AGREE).
   Also `02_where.toml :: in_list_with_null_literal`, `in_subquery_then_and` (DIFFER).
@@ -727,7 +732,8 @@ annotation be removed.
   root equality is reached through at least three surfaces.
 
 ### P19 — `NOT IN` does not exclude NULLs
-- **Status:** 🔴 OPEN — same family as P18
+- **Status:** 🟡 IN PROGRESS — same family as P18, same groundwork
+  ([R10](ENGINE_REFACTORING.md#r10) slice 1a landed 2026-08-22)
 - **Corpus:** `10_aggregate_nulls.toml :: where_not_in_excludes_null` (DIFFER).
   Baselines: `where_not_equal_excludes_null`, `where_in_with_null_col` (AGREE).
 - **Observed:** `WHERE score NOT IN (50, 70)` returns 8 rows including the

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -44,6 +44,7 @@ pub mod recursive_where_evaluator;
 pub mod row_expanders; // Row expansion system (UNNEST, etc.)
 pub mod subquery_executor;
 pub mod temp_table_registry; // Temporary tables for script execution
+pub mod trilean; // Three-valued logic (TRUE/FALSE/UNKNOWN) for SQL predicates
 pub mod unit_converter;
 pub mod virtual_table_generator;
 

--- a/src/data/trilean.rs
+++ b/src/data/trilean.rs
@@ -1,0 +1,320 @@
+//! Three-valued logic (`TRUE` / `FALSE` / `UNKNOWN`) for SQL predicate evaluation.
+//!
+//! SQL does not evaluate predicates in boolean logic — it evaluates them in
+//! *three-valued* logic, where a comparison involving NULL yields `UNKNOWN`
+//! rather than true or false. `UNKNOWN` is not "false"; the distinction only
+//! collapses at the very end, where `WHERE` keeps a row **only if the predicate
+//! is `TRUE`**. That deferred collapse is the whole point: `NOT UNKNOWN` is
+//! `UNKNOWN` (still not kept), whereas `!false` is `true` (kept, wrongly).
+//!
+//! The WHERE evaluator historically returned `Result<bool>`, so `UNKNOWN` could
+//! not be represented at all and `NOT` / `NOT IN` flipped it into `TRUE` —
+//! producing extra rows. See findings P18/P19 in `docs/SQL_PARITY.md`.
+//!
+//! This module is deliberately standalone: it defines the truth tables and
+//! proves them with tests, ahead of the evaluator being converted to use it.
+
+use std::fmt;
+use std::ops::{BitAnd, BitOr, Not};
+
+/// A SQL truth value: `TRUE`, `FALSE`, or `UNKNOWN`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Trilean {
+    True,
+    False,
+    /// The result of any comparison involving NULL.
+    Unknown,
+}
+
+impl Trilean {
+    /// Lift a boolean into three-valued logic.
+    pub fn from_bool(b: bool) -> Self {
+        if b {
+            Trilean::True
+        } else {
+            Trilean::False
+        }
+    }
+
+    /// Lift a comparison whose operands may be NULL: `None` means an operand
+    /// was NULL, which is `UNKNOWN` — never `FALSE`.
+    pub fn from_option(b: Option<bool>) -> Self {
+        match b {
+            Some(v) => Trilean::from_bool(v),
+            None => Trilean::Unknown,
+        }
+    }
+
+    /// The single semantic boundary: `WHERE` / `HAVING` / `ON` keep a row only
+    /// when the predicate is `TRUE`. `UNKNOWN` is dropped, exactly like `FALSE`.
+    ///
+    /// This is the *only* sanctioned way to turn a `Trilean` back into a
+    /// `bool` for row filtering — collapsing earlier is what reintroduces
+    /// P18/P19.
+    pub fn is_true(self) -> bool {
+        matches!(self, Trilean::True)
+    }
+
+    pub fn is_false(self) -> bool {
+        matches!(self, Trilean::False)
+    }
+
+    pub fn is_unknown(self) -> bool {
+        matches!(self, Trilean::Unknown)
+    }
+
+    /// SQL `AND`. `UNKNOWN AND FALSE` is `FALSE` — a false operand short-circuits
+    /// even when the other side is unknown.
+    pub fn and(self, other: Trilean) -> Trilean {
+        match (self, other) {
+            (Trilean::False, _) | (_, Trilean::False) => Trilean::False,
+            (Trilean::True, Trilean::True) => Trilean::True,
+            _ => Trilean::Unknown,
+        }
+    }
+
+    /// SQL `OR`. `UNKNOWN OR TRUE` is `TRUE` — a true operand short-circuits
+    /// even when the other side is unknown.
+    pub fn or(self, other: Trilean) -> Trilean {
+        match (self, other) {
+            (Trilean::True, _) | (_, Trilean::True) => Trilean::True,
+            (Trilean::False, Trilean::False) => Trilean::False,
+            _ => Trilean::Unknown,
+        }
+    }
+
+    /// SQL `NOT`. `NOT UNKNOWN` is `UNKNOWN`, **not** `TRUE`.
+    pub fn negate(self) -> Trilean {
+        match self {
+            Trilean::True => Trilean::False,
+            Trilean::False => Trilean::True,
+            Trilean::Unknown => Trilean::Unknown,
+        }
+    }
+
+    /// `IS TRUE` / `IS FALSE` / `IS UNKNOWN` predicates, which are themselves
+    /// always two-valued: they never yield `UNKNOWN`.
+    pub fn is_predicate(self, expected: Trilean) -> Trilean {
+        Trilean::from_bool(self == expected)
+    }
+}
+
+impl From<bool> for Trilean {
+    fn from(b: bool) -> Self {
+        Trilean::from_bool(b)
+    }
+}
+
+impl From<Option<bool>> for Trilean {
+    fn from(b: Option<bool>) -> Self {
+        Trilean::from_option(b)
+    }
+}
+
+impl BitAnd for Trilean {
+    type Output = Trilean;
+    fn bitand(self, rhs: Trilean) -> Trilean {
+        self.and(rhs)
+    }
+}
+
+impl BitOr for Trilean {
+    type Output = Trilean;
+    fn bitor(self, rhs: Trilean) -> Trilean {
+        self.or(rhs)
+    }
+}
+
+impl Not for Trilean {
+    type Output = Trilean;
+    fn not(self) -> Trilean {
+        self.negate()
+    }
+}
+
+impl fmt::Display for Trilean {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Trilean::True => "TRUE",
+            Trilean::False => "FALSE",
+            Trilean::Unknown => "UNKNOWN",
+        };
+        f.write_str(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Trilean::{False, True, Unknown};
+    use super::*;
+
+    const ALL: [Trilean; 3] = [True, False, Unknown];
+
+    // --- Truth tables, written out in full rather than derived, so a change to
+    // --- the implementation cannot silently change what we assert.
+
+    #[test]
+    fn and_truth_table() {
+        let table = [
+            (True, True, True),
+            (True, False, False),
+            (True, Unknown, Unknown),
+            (False, True, False),
+            (False, False, False),
+            (False, Unknown, False), // FALSE dominates, even over UNKNOWN
+            (Unknown, True, Unknown),
+            (Unknown, False, False), // ditto, reversed
+            (Unknown, Unknown, Unknown),
+        ];
+        for (a, b, expected) in table {
+            assert_eq!(a.and(b), expected, "{a} AND {b}");
+            assert_eq!(a & b, expected, "{a} & {b}");
+        }
+    }
+
+    #[test]
+    fn or_truth_table() {
+        let table = [
+            (True, True, True),
+            (True, False, True),
+            (True, Unknown, True), // TRUE dominates, even over UNKNOWN
+            (False, True, True),
+            (False, False, False),
+            (False, Unknown, Unknown),
+            (Unknown, True, True), // ditto, reversed
+            (Unknown, False, Unknown),
+            (Unknown, Unknown, Unknown),
+        ];
+        for (a, b, expected) in table {
+            assert_eq!(a.or(b), expected, "{a} OR {b}");
+            assert_eq!(a | b, expected, "{a} | {b}");
+        }
+    }
+
+    #[test]
+    fn not_truth_table() {
+        assert_eq!(True.negate(), False);
+        assert_eq!(False.negate(), True);
+        // The whole reason this type exists: NOT UNKNOWN is UNKNOWN, and a
+        // bool-valued evaluator turns it into TRUE. See P18/P19.
+        assert_eq!(Unknown.negate(), Unknown);
+        for a in ALL {
+            assert_eq!(!a, a.negate());
+        }
+    }
+
+    // --- Algebraic laws. These hold in 3VL and are the properties the
+    // --- evaluator's rewrites (De Morgan, double negation) rely on.
+
+    #[test]
+    fn double_negation_is_identity() {
+        for a in ALL {
+            assert_eq!(a.negate().negate(), a, "NOT NOT {a}");
+        }
+    }
+
+    #[test]
+    fn de_morgan_holds() {
+        for a in ALL {
+            for b in ALL {
+                assert_eq!(
+                    (a.and(b)).negate(),
+                    a.negate().or(b.negate()),
+                    "NOT({a} AND {b})"
+                );
+                assert_eq!(
+                    (a.or(b)).negate(),
+                    a.negate().and(b.negate()),
+                    "NOT({a} OR {b})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn and_or_are_commutative_and_associative() {
+        for a in ALL {
+            for b in ALL {
+                assert_eq!(a.and(b), b.and(a));
+                assert_eq!(a.or(b), b.or(a));
+                for c in ALL {
+                    assert_eq!(a.and(b).and(c), a.and(b.and(c)));
+                    assert_eq!(a.or(b).or(c), a.or(b.or(c)));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn identity_and_annihilator_elements() {
+        for a in ALL {
+            assert_eq!(a.and(True), a, "{a} AND TRUE");
+            assert_eq!(a.and(False), False, "{a} AND FALSE");
+            assert_eq!(a.or(False), a, "{a} OR FALSE");
+            assert_eq!(a.or(True), True, "{a} OR TRUE");
+        }
+    }
+
+    /// The law of excluded middle does *not* hold in 3VL — `x OR NOT x` is
+    /// UNKNOWN when x is UNKNOWN. Asserting this pins the difference from bool.
+    #[test]
+    fn excluded_middle_fails_for_unknown() {
+        assert_eq!(True.or(True.negate()), True);
+        assert_eq!(False.or(False.negate()), True);
+        assert_eq!(Unknown.or(Unknown.negate()), Unknown);
+        assert_eq!(Unknown.and(Unknown.negate()), Unknown);
+    }
+
+    // --- The boundary.
+
+    #[test]
+    fn where_keeps_only_true() {
+        assert!(True.is_true());
+        assert!(!False.is_true());
+        // UNKNOWN rows are dropped by WHERE, same as FALSE.
+        assert!(!Unknown.is_true());
+    }
+
+    #[test]
+    fn boolean_subset_matches_two_valued_logic() {
+        // Over TRUE/FALSE only, Trilean must behave exactly like bool, which is
+        // what makes wiring it in a provable no-op until the NULL paths change.
+        for a in [true, false] {
+            for b in [true, false] {
+                let (ta, tb) = (Trilean::from_bool(a), Trilean::from_bool(b));
+                assert_eq!(ta.and(tb).is_true(), a && b);
+                assert_eq!(ta.or(tb).is_true(), a || b);
+                assert_eq!(ta.negate().is_true(), !a);
+            }
+        }
+    }
+
+    #[test]
+    fn lifting_from_option() {
+        assert_eq!(Trilean::from_option(Some(true)), True);
+        assert_eq!(Trilean::from_option(Some(false)), False);
+        // A NULL operand is UNKNOWN, never FALSE — the mistake this type exists
+        // to prevent.
+        assert_eq!(Trilean::from_option(None), Unknown);
+        assert_eq!(Trilean::from(None::<bool>), Unknown);
+        assert_eq!(Trilean::from(true), True);
+    }
+
+    #[test]
+    fn is_predicates_are_two_valued() {
+        for a in ALL {
+            for expected in ALL {
+                let r = a.is_predicate(expected);
+                assert!(!r.is_unknown(), "{a} IS {expected} must not be UNKNOWN");
+                assert_eq!(r.is_true(), a == expected);
+            }
+        }
+    }
+
+    #[test]
+    fn display_uses_sql_spelling() {
+        assert_eq!(True.to_string(), "TRUE");
+        assert_eq!(False.to_string(), "FALSE");
+        assert_eq!(Unknown.to_string(), "UNKNOWN");
+    }
+}


### PR DESCRIPTION
Groundwork for parity findings [P18](../blob/main/docs/SQL_PARITY.md#p18)/[P19](../blob/main/docs/SQL_PARITY.md#p19), filed as **R10 slice 1a**. Nothing is wired — no engine path references the new module.

## Why a type change comes first

The WHERE evaluator returns `Result<bool>`, so `UNKNOWN` cannot be represented at all: `NOT` is `Ok(!inner)` and `NOT IN` is `Ok(!in_result)`. Under three-valued logic `NOT UNKNOWN` is `UNKNOWN`, but with `bool` it collapses to false and then flips to **true** — which is mechanically how P19 admits rows that must not pass. That makes P18/P19 a type change before it is a semantics change, and patching per-operator cannot work.

## What's here

- `src/data/trilean.rs` — `Trilean::{True, False, Unknown}`, the SQL `AND`/`OR`/`NOT` truth tables, and `is_true()` documented as the **only** sanctioned collapse back to `bool`. Collapsing anywhere else is what reintroduces the bug.
- 13 unit tests. The truth tables are written out cell by cell rather than derived from the implementation, so a change to the code cannot silently change what we assert. They also cover the algebraic laws the evaluator's rewrites lean on (double negation, De Morgan, associativity) and the one that **fails** in 3VL — `x OR NOT x` is `UNKNOWN` when `x` is, which is exactly where a `bool` evaluator goes wrong.
- `boolean_subset_matches_two_valued_logic` pins `Trilean` to behave exactly like `bool` over TRUE/FALSE. That is half the proof that slice 1b cannot change results.
- `docs/ENGINE_REFACTORING.md` — R10 filed with the 1a/1b/1c slicing and why the split is worth it; `docs/SQL_PARITY.md` — P18/P19 moved to IN PROGRESS with cross-links.

## Verification

- `cargo test` — **710 passed, 0 failed** (13 new)
- Parity corpus vs DuckDB — **exactly 125 AGREE / 159**, unmoved. That is the acceptance test for unwired groundwork
- All FORMAL examples pass; `cargo fmt --check` clean; no new clippy findings

## Next

- **1b** — convert the evaluator to `Trilean` internally and collapse `Unknown → false` at the single row-filter boundary in `query_engine.rs`. A no-op by construction; acceptance test is that parity stays at exactly 125 AGREE.
- **1c** — flip the semantics (`= NULL`, `IN` with a NULL in the list, `NOT IN`, `NOT`). This one changes results and will churn FORMAL expectations; each diff gets verified against DuckDB before re-capturing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
