### PR TITLE
fix(ci): key the Python venv cache on the interpreter version

### DIFF
--- a/.github/workflows/test-complete.yml
+++ b/.github/workflows/test-complete.yml
@@ -68,15 +68,16 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
+      id: setup-python
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    
+
     - name: Install uv
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-    
+
     - name: Set up Rust (for building sql-cli)
       uses: actions-rs/toolchain@v1
       with:
@@ -99,15 +100,24 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: ${{ runner.os }}-python-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+        # The interpreter version MUST be in the key. A .venv is a set of
+        # symlinks into the hosted toolcache, so a venv built against
+        # 3.10.<old> is broken the moment the runner image ships 3.10.<new>
+        # and deletes the old directory. `python-version: '3.10'` floats across
+        # patch releases, so this happens without any change on our side.
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
         restore-keys: |
-          ${{ runner.os }}-python-
-    
+          ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-
+
     - name: Install Python dependencies
       run: |
-        # Only create .venv if the cache step didn't restore one.
-        # Newer uv versions refuse to overwrite an existing venv without --clear.
-        [ -d .venv ] || uv venv
+        # Recreate unless the restored .venv has a working interpreter. Testing
+        # `-d .venv` is not enough: a cache hit against a since-removed patch
+        # release leaves the directory present with a dangling
+        # .venv/bin/python symlink, and uv then fails with "Broken symlink"
+        # rather than repairing it. `-x` follows the symlink, so it is false
+        # exactly when the target is gone.
+        [ -x .venv/bin/python ] || uv venv --clear
         uv pip install -e .
         uv pip install pytest pytest-cov pandas numpy
     
@@ -320,9 +330,11 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        # Only create .venv if one doesn't already exist.
-        # Newer uv versions refuse to overwrite an existing venv without --clear.
-        [ -d .venv ] || uv venv
+        # Recreate unless an existing .venv has a working interpreter — see the
+        # Python Tests job for why `-d` is the wrong test. This job caches no
+        # .venv, so it cannot hit the stale-symlink case today; kept identical
+        # so the two don't drift into different failure modes.
+        [ -x .venv/bin/python ] || uv venv --clear
         uv pip install pandas numpy
 
     - name: Run performance benchmarks


### PR DESCRIPTION
`Python Tests (Linux)` has started failing on every run, on every branch, at the **Install Python dependencies** step — before a single test executes:

```
error: Failed to inspect Python interpreter from virtual environment at `.venv/bin/python3`
  Caused by: Broken symlink at `.venv/bin/python3`, was the underlying Python interpreter removed?
```

## Cause

Nothing changed on our side. A `.venv` is a set of symlinks into the hosted toolcache, and `python-version: '3.10'` floats across patch releases. The runner image shipped a new 3.10.x and deleted `/opt/hostedtoolcache/Python/3.10.<old>/x64`, so every cached venv now points at a path that no longer exists.

Two things turned that into a hard failure rather than a self-repair:

1. The cache key hashed only `pyproject.toml`/`uv.lock` — **not** the interpreter version — so a venv built against the old patch release was restored against the new one. This is also why **re-running never helped**: the same poisoned cache comes back every time.
2. The guard `[ -d .venv ] || uv venv` tests only that the *directory* exists. A dangling symlink still lives in a perfectly real directory, so creation was skipped and `uv pip install` hit the broken interpreter.

## Fix

Either half is sufficient; both are cheap, and they fail in different ways so it's worth having both.

- **Cache key carries the resolved interpreter version** (via `steps.setup-python.outputs.python-version`), in `restore-keys` as well as `key`. Version-agnostic restore-keys would have handed back the same broken venv on a key miss.
- **Guard tests `-x .venv/bin/python`** instead of `-d .venv`. `-x` follows the symlink, so it is false exactly when the target is gone, and `uv venv --clear` repairs it in place. This makes the job self-healing against the same class of breakage from any cause, not just this one.

The benchmark job caches no venv so it cannot hit this today, but it carried the same `-d` guard — aligned so the two don't drift into different failure modes.

CI-only; no engine or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
