### PR TITLE
fix(engine): evaluate NULL predicates as UNKNOWN, not false (P18/P19)

### DIFF
--- a/docs/ENGINE_REFACTORING.md
+++ b/docs/ENGINE_REFACTORING.md
@@ -319,8 +319,8 @@ feature work**, and so we can tell the difference between "this is awkward" and
   the same failure mode as [R3](#r3)'s catch-all arms, one layer down.
 
 ### R10 — Predicate evaluation has no way to say UNKNOWN
-- **Status:** 🟡 IN PROGRESS — slices 1a and 1b done 2026-08-22; **1c** (the
-  semantics flip, which is what actually closes P18/P19) outstanding
+- **Status:** 🟢 DONE 2026-08-22 — all three slices landed the same day;
+  closes [P18](SQL_PARITY.md#p18) and [P19](SQL_PARITY.md#p19), parity 125 → 129
 - **Where:** `src/data/recursive_where_evaluator.rs` (9 `Result<bool>`
   signatures, 14 match arms), two construction sites in
   `src/data/query_engine.rs`, and one semantic boundary — the
@@ -358,18 +358,32 @@ feature work**, and so we can tell the difference between "this is awkward" and
     `is_true()`/`is_false()`; `is_false()` is deliberately used for the negative
     cases rather than `!is_true()`, so that when 1c lands, a result that turns
     UNKNOWN fails the assertion instead of silently satisfying it.
-  - **1c — outstanding, and the only slice that changes results.** Flip the
-    semantics (`= NULL`, `IN` with a NULL in the list, `NOT IN`, `NOT`). The
-    propagation is already wired, so 1c is about *producing* UNKNOWN at the
-    leaves. The three sites are marked in the source with comments naming P18
-    and P19 (`grep -n P18 src/data/recursive_where_evaluator.rs`):
-    `compare_with_op`'s result in `evaluate_binary_op`, the equality inside
-    `evaluate_in_list`, and the NULL arms that currently answer FALSE. Expect
-    FORMAL example churn; verify each diff against DuckDB before re-capturing.
-- **Why the split is worth it:** 1b is a large mechanical diff with zero
-  behaviour change, and 1c is a small diff with all of it. Landing them together
-  would mean reviewing a semantic change buried in 200 lines of signature
-  churn — and leave no checkpoint to bisect against if parity moves.
+  - **1c — done 2026-08-22, the only slice that changed results.** UNKNOWN is
+    now produced at the leaves and the already-wired propagation does the rest.
+    The whole semantic change is one helper, `compare_trilean`: if either
+    operand is NULL the answer is UNKNOWN. It is applied at the comparison arm,
+    inside `evaluate_in_list`, in `BETWEEN`'s two bounds, in `LIKE`, and to the
+    arithmetic evaluator's NULL result. **~40 lines**, which is the payoff for
+    having shipped 1a/1b separately.
+    **The root cause was one line in a function nobody would have suspected:**
+    `compare_values` reports `(Null, Null) => Some(Ordering::Equal)`. That is
+    *correct* — `ORDER BY` needs NULLs to group together — and the WHERE
+    evaluator was reusing the same answer, which is why `= NULL` behaved like
+    `IS NULL`. The fix tests for NULL at the predicate layer and leaves the
+    shared comparator alone; pushing it down would have broken sorting.
+    No FORMAL example churn materialised — none of them exercise NULL
+    predicates — so the P21 re-capture warning did not bite this time.
+- **Why the split was worth it, in hindsight:** 1b was 187 changed lines with
+  zero behaviour change; 1c was ~40 lines with all of it. Landed together, the
+  semantics would have been reviewed inside a wall of signature churn, and there
+  would have been no checkpoint to bisect against. The split also made the
+  acceptance criteria different in kind — 1b had to leave parity *exactly*
+  unmoved, 1c had to move exactly the four pinned cases and nothing else. Both
+  held.
+- **Reusable method:** for a type change of this shape, change the signatures
+  first and let `rustc` enumerate the leaves (57 here) instead of grepping for
+  them. The compiler's list is exhaustive by definition; the transform was
+  applied from its own line/column output.
 
 ---
 
@@ -392,7 +406,7 @@ R1 FROM migration ── independent; deferred (larger than P3)
 R4 fixtures ──────── adopt opportunistically, per transformer touched
 R5 dead code ─────── opportunistic
 R8 legacy WHERE ──── independent; stage 2 is self-contained, do it in a lull
-R10 Trilean ──────── 1a+1b landed (no-op); 1c flips semantics, closes P18/P19
+R10 Trilean ──────── DONE; closed P18/P19 (parity 125 → 129)
 ```
 
 **A note on ordering, from the P18/P19 work being next.** The WHERE evaluator
@@ -422,4 +436,5 @@ AGREE count — which makes it safe to land well before the semantics change.
 | 2026-08-08 | R8 filed and stage 1 done: 830 lines of zero-caller legacy WHERE deleted (`where_clause_converter`, `where_evaluator`, `simple_where`) plus `DebugWidget`'s dead WHERE-AST code. No behaviour change | #47 |
 | 2026-08-16 | R9 filed and done: view→table materialization consolidated on `materialize_view`; `DataView` gains `windowed_row_indices`/`with_max_rows`. Closes parity P28 and P31 | — |
 | 2026-08-22 | R10 filed; slice 1a landed: `data::trilean` with the 3VL truth tables and 13 unit tests. Unwired — no behaviour change, parity unmoved at 125/159 | #51 |
-| 2026-08-22 | R10 slice 1b: WHERE evaluator converted to `Result<Trilean>`; `is_true()` collapse at the single row-filter boundary. `Unknown` still never constructed, so no behaviour change — parity unmoved at 125/159 | — |
+| 2026-08-22 | R10 slice 1b: WHERE evaluator converted to `Result<Trilean>`; `is_true()` collapse at the single row-filter boundary. `Unknown` still never constructed, so no behaviour change — parity unmoved at 125/159 | #53 |
+| 2026-08-22 | R10 slice 1c: UNKNOWN produced at the leaves via `compare_trilean`. Closes parity P18/P19 — 125 → **129 AGREE**; new finding P32 (`NOT LIKE` parse gap) pinned, not fixed | — |

--- a/docs/SQL_PARITY.md
+++ b/docs/SQL_PARITY.md
@@ -80,10 +80,10 @@ Suggested fix order, by silent blast radius:
 | ~~3~~ | ~~[P30](#p30) `cond AND col IN (list)` returns 0 rows~~ | ✅ **Fixed 2026-08-08** |
 | ~~5~~ | ~~[P29](#p29) boolean operator after `IN (...)`~~ | ✅ **Fixed 2026-08-08** — same bug as P30, one change closed both |
 | ~~4~~ | ~~[P28](#p28) `INTO #tmp` stages unfiltered rows~~ | ✅ **Fixed 2026-08-16** — turned out to stage the *whole source table*, and the sweep it prescribed found [P31](#p31) |
-| **7** | **[P18](#p18)/[P19](#p19) three-valued logic** | Promoted: silent, P18 produces *extra* rows, and it now blocks two more corpus cases that the P29 fix uncovered. **Groundwork complete 2026-08-22** — the `Trilean` type and the evaluator conversion both landed with parity unmoved ([R10](ENGINE_REFACTORING.md#r10) slices 1a/1b); only the semantics flip (1c) is left |
+| ~~7~~ | ~~[P18](#p18)/[P19](#p19) three-valued logic~~ | ✅ **Fixed 2026-08-22** — 125 → 129 AGREE. Delivered as three slices ([R10](ENGINE_REFACTORING.md#r10)); the two no-op ones landed first, so the semantics change reviewed on its own |
 | 8 | [P24](#p24) `RANGE` treated as `ROWS` | Silent, hits the common `SUM(x) OVER (ORDER BY y)` running-total form |
 | 9 | [P14](#p14), [P16](#p16), [P17](#p17), [P20](#p20), [P23](#p23), P13 stage 2 | Smaller, self-contained, decisions already taken |
-| 10 | [P22](#p22), [P25](#p25), [P26](#p26), [P15](#p15) | Hard errors — visible, so less urgent than any of the above |
+| 10 | [P22](#p22), [P25](#p25), [P26](#p26), [P15](#p15), [P32](#p32) | Hard errors — visible, so less urgent than any of the above |
 | — | [P27](#p27) `OR` in `JOIN ... ON` | **Reclassified 2026-08-08 — not a quick win.** `JoinCondition` is a `Vec<SingleJoinCondition>` implicitly AND-ed, so there is nowhere in the AST to put an `OR`; it needs join conditions to become an expression, which reaches the join execution code. Sequence it with the R-log, not here |
 
 P27–P30 jump the queue because all four were found *by* fixing something else,
@@ -699,17 +699,16 @@ annotation be removed.
   the two ASC cases flip DIFFER → AGREE and their `expect` should be dropped.
 
 ### P18 — `= NULL` matches NULL rows instead of yielding UNKNOWN
-- **Status:** 🟡 IN PROGRESS — groundwork started 2026-08-22; **second site
-  found 2026-08-08, see below**
-- **Groundwork:** the fix is gated on the evaluator being able to *represent*
-  UNKNOWN at all — see [R10](ENGINE_REFACTORING.md#r10) for the slicing. Both
-  no-op slices landed 2026-08-22: `src/data/trilean.rs` (the type and its truth
-  tables), then the WHERE evaluator converted to `Result<Trilean>` with the
-  UNKNOWN→false collapse at the single row-filter boundary. Parity was unmoved
-  at 125 AGREE across both, because `Trilean::Unknown` is still constructed
-  nowhere. **All that remains is slice 1c — producing UNKNOWN at the leaves**,
-  which closes this entry together with P19. The three sites are marked in the
-  source: `grep -n P18 src/data/recursive_where_evaluator.rs`.
+- **Status:** 🟢 FIXED 2026-08-22, with P19 — branch
+  `fix/p18-p19-three-valued-logic`. Parity 125 → **129 AGREE**; four cases
+  closed at once (`where_equals_null`, `where_not_in_excludes_null`,
+  `in_list_with_null_literal`, `in_subquery_then_and`).
+- **Delivered in three slices** ([R10](ENGINE_REFACTORING.md#r10)), only the
+  last of which changed any result: the `Trilean` type and its truth tables
+  (1a), the evaluator converted to `Result<Trilean>` with one collapse point
+  (1b), then UNKNOWN produced at the leaves (1c). The first two were provable
+  no-ops and shipped separately, so the review of the semantics change was a
+  ~40-line diff rather than one buried in 200 lines of signature churn.
 - **Corpus:** `10_aggregate_nulls.toml :: where_equals_null` (DIFFER).
   Baseline: `where_is_null` (AGREE).
   Also `02_where.toml :: in_list_with_null_literal`, `in_subquery_then_and` (DIFFER).
@@ -737,8 +736,9 @@ annotation be removed.
   root equality is reached through at least three surfaces.
 
 ### P19 — `NOT IN` does not exclude NULLs
-- **Status:** 🟡 IN PROGRESS — same family as P18, same groundwork
-  ([R10](ENGINE_REFACTORING.md#r10) slice 1a landed 2026-08-22)
+- **Status:** 🟢 FIXED 2026-08-22, with P18 — one change closed both, as
+  predicted: they are the same missing propagation reached through different
+  operators.
 - **Corpus:** `10_aggregate_nulls.toml :: where_not_in_excludes_null` (DIFFER).
   Baselines: `where_not_equal_excludes_null`, `where_in_with_null_col` (AGREE).
 - **Observed:** `WHERE score NOT IN (50, 70)` returns 8 rows including the
@@ -1031,6 +1031,25 @@ annotation be removed.
   materialization helper rather than a copy loop per call site — and it is what
   the P28 entry's "check whether any other consumer takes the same route" note
   was for. **The note worked; make that sweep routine.**
+
+### P32 — `NOT LIKE` does not parse
+- **Status:** 🔴 OPEN — hard error, low urgency
+- **Corpus:** `02_where.toml :: not_like_pattern` (GAP)
+- **Observed:** `WHERE label NOT LIKE 'a%'` fails to parse with
+  `Expected IN after NOT` — `NOT` accepts only `IN` after it. `NOT (x LIKE ..)`
+  is the working spelling.
+- **Found 2026-08-22 while verifying the P18/P19 fix against DuckDB**, and
+  **pre-existing** — confirmed against `main`, unrelated to the three-valued
+  logic work. Pinned rather than fixed in that change, per the standing rule
+  that a divergence found while fixing something else gets its own entry.
+- **Visible, so it ranks below any silent finding.** It is a parse error, not a
+  wrong answer: nobody gets bad data from it.
+- **The evaluator half is already done.** DuckDB returns ids 1,3,4,7,8,9 for the
+  corpus query — note it *excludes* the NULL-label rows, which is the same
+  UNKNOWN-under-`NOT` rule as P19. Our `LIKE` already returns UNKNOWN for a NULL
+  operand as of the P18/P19 fix, so closing this is a parser change alone, and
+  the corpus case doubles as proof that `NOT LIKE` inherits the NULL semantics
+  rather than growing its own.
 
 ---
 

--- a/src/data/recursive_where_evaluator.rs
+++ b/src/data/recursive_where_evaluator.rs
@@ -148,6 +148,27 @@ impl<'a, 'ctx, 'exec> RecursiveWhereEvaluator<'a, 'ctx, 'exec> {
         }
     }
 
+    /// Compare two values under SQL three-valued logic: if **either** operand
+    /// is NULL the answer is UNKNOWN, never TRUE or FALSE.
+    ///
+    /// This test has to live here, at the predicate layer, and must not be
+    /// pushed down into `compare_with_op`. That function answers in `bool`, and
+    /// the `compare_values` beneath it deliberately reports `NULL = NULL` as
+    /// `Ordering::Equal` because **`ORDER BY` needs NULLs to group together**.
+    /// Correct for sorting, wrong for predicates — and using the one answer for
+    /// both is what made `WHERE score = NULL` return the NULL rows (P18).
+    ///
+    /// `IS NULL` / `IS NOT NULL` / `IS [NOT] NULL` are handled by their own
+    /// match arms before reaching any caller of this, and stay two-valued —
+    /// they are the sanctioned way to test for NULL, which is why nothing is
+    /// lost by making `=` never match one.
+    fn compare_trilean(&self, left: &DataValue, right: &DataValue, op: &str) -> Trilean {
+        if matches!(left, DataValue::Null) || matches!(right, DataValue::Null) {
+            return Trilean::Unknown;
+        }
+        Trilean::from_bool(compare_with_op(left, right, op, self.case_insensitive))
+    }
+
     /// Convert ExprValue to DataValue for centralized comparison
     fn expr_value_to_data_value(&self, expr_value: &ExprValue) -> DataValue {
         match expr_value {
@@ -582,10 +603,12 @@ impl<'a, 'ctx, 'exec> RecursiveWhereEvaluator<'a, 'ctx, 'exec> {
             let mut evaluator = ArithmeticEvaluator::new(self.table);
             let result = evaluator.evaluate(&comparison_expr, row_index)?;
 
-            // Convert the result to boolean
+            // Convert the result to a truth value. A NULL out of the
+            // arithmetic evaluator means a NULL propagated through the
+            // expression, so the comparison is UNKNOWN rather than false.
             return match result {
                 DataValue::Boolean(b) => Ok(Trilean::from_bool(b)),
-                DataValue::Null => Ok(Trilean::False),
+                DataValue::Null => Ok(Trilean::Unknown),
                 _ => Err(anyhow!("Comparison did not return a boolean value")),
             };
         }
@@ -684,12 +707,18 @@ impl<'a, 'ctx, 'exec> RecursiveWhereEvaluator<'a, 'ctx, 'exec> {
                 let table_value = cell_value.unwrap_or(DataValue::Null);
                 let pattern = match compare_value {
                     ExprValue::String(s) => s,
+                    // A NULL pattern makes the whole predicate UNKNOWN; any
+                    // other non-string pattern is simply not a match.
+                    ExprValue::Null => return Ok(Trilean::Unknown),
                     _ => return Ok(Trilean::False),
                 };
 
                 let text = match &table_value {
                     DataValue::String(s) => s.as_str(),
                     DataValue::InternedString(s) => s.as_str(),
+                    // Likewise on the value side: NULL LIKE '...' is UNKNOWN,
+                    // which matters under NOT — see P19.
+                    DataValue::Null => return Ok(Trilean::Unknown),
                     _ => return Ok(Trilean::False),
                 };
 
@@ -738,16 +767,7 @@ impl<'a, 'ctx, 'exec> RecursiveWhereEvaluator<'a, 'ctx, 'exec> {
                     );
                 }
 
-                Ok(Trilean::from_bool(compare_with_op(
-                    &table_value,
-                    &comparison_value,
-                    op,
-                    self.case_insensitive,
-                )))
-                // P18 lives here: `compare_with_op` answers in `bool`, so a
-                // NULL on either side comes back FALSE — except for `=`, where
-                // NULL = NULL currently answers TRUE. Slice 1c returns UNKNOWN
-                // whenever either side is NULL and lets it propagate.
+                Ok(self.compare_trilean(&table_value, &comparison_value, op))
             }
         }
     }
@@ -790,23 +810,31 @@ impl<'a, 'ctx, 'exec> RecursiveWhereEvaluator<'a, 'ctx, 'exec> {
     ) -> Result<Trilean> {
         let cell_value = self.evaluate_operand_value(expr, row_index)?;
 
+        // `x IN (a, b, ...)` is `x = a OR x = b OR ...`, so it inherits OR's
+        // truth table: a TRUE anywhere wins outright, but if nothing matched
+        // and any comparison was UNKNOWN, the answer is UNKNOWN — not FALSE.
+        // That distinction is invisible under `IN` (both drop the row) and is
+        // the whole of P19 under `NOT IN`, where FALSE would wrongly negate to
+        // TRUE and admit the NULL rows.
+        let mut saw_unknown = false;
+
         for value_expr in values {
             let compare_value = self.extract_value(value_expr)?;
             let table_value = cell_value.as_ref().unwrap_or(&DataValue::Null);
             let comparison_value = self.expr_value_to_data_value(&compare_value);
 
-            // Use centralized comparison for equality
-            // P18's second site: `IN` is built on this same equality, so a NULL
-            // *in the list* currently matches every NULL row. Slice 1c makes a
-            // NULL comparison UNKNOWN, and `IN` then has to remember whether it
-            // saw one — no match plus an UNKNOWN is UNKNOWN, not FALSE, which
-            // is also what makes `NOT IN` exclude NULLs (P19).
-            if compare_with_op(table_value, &comparison_value, "=", self.case_insensitive) {
-                return Ok(Trilean::True);
+            match self.compare_trilean(table_value, &comparison_value, "=") {
+                Trilean::True => return Ok(Trilean::True),
+                Trilean::Unknown => saw_unknown = true,
+                Trilean::False => {}
             }
         }
 
-        Ok(Trilean::False)
+        Ok(if saw_unknown {
+            Trilean::Unknown
+        } else {
+            Trilean::False
+        })
     }
 
     fn evaluate_between(
@@ -824,13 +852,14 @@ impl<'a, 'ctx, 'exec> RecursiveWhereEvaluator<'a, 'ctx, 'exec> {
         let lower_data_value = self.expr_value_to_data_value(&lower_value);
         let upper_data_value = self.expr_value_to_data_value(&upper_value);
 
-        // Use centralized comparison for BETWEEN: value >= lower AND value <= upper
-        let ge_lower =
-            compare_with_op(&table_value, &lower_data_value, ">=", self.case_insensitive);
-        let le_upper =
-            compare_with_op(&table_value, &upper_data_value, "<=", self.case_insensitive);
+        // BETWEEN is defined as `value >= lower AND value <= upper`, so it takes
+        // AND's truth table too: FALSE on either side still wins outright (a
+        // value below `lower` is not between, whatever `upper` is), and UNKNOWN
+        // only survives when the other side is TRUE or UNKNOWN.
+        let ge_lower = self.compare_trilean(&table_value, &lower_data_value, ">=");
+        let le_upper = self.compare_trilean(&table_value, &upper_data_value, "<=");
 
-        Ok(Trilean::from_bool(ge_lower && le_upper))
+        Ok(ge_lower.and(le_upper))
     }
 
     fn evaluate_method_call(
@@ -1168,4 +1197,197 @@ enum ExprValue {
     Boolean(bool),
     DateTime(DateTime<Utc>),
     Null,
+}
+
+#[cfg(test)]
+mod three_valued_logic_tests {
+    //! Regression tests for P18/P19 — SQL three-valued logic in `WHERE`.
+    //!
+    //! These assert the `Trilean` the evaluator produces for a single row,
+    //! rather than the rows a query returns, because that is where the defect
+    //! actually lived: UNKNOWN and FALSE are indistinguishable by row count
+    //! under `WHERE` (both drop the row) and only diverge under `NOT`. A
+    //! row-counting test would have passed against the broken evaluator for
+    //! half of these cases.
+    //!
+    //! They also run without DuckDB, unlike the corpus cases in
+    //! `tests/comparison/corpus/` that pin the same behaviour end to end.
+
+    use super::*;
+    use crate::data::datatable::{DataColumn, DataRow};
+    use crate::sql::recursive_parser::Parser;
+
+    /// Rows: 0 = score 50, 1 = score 30, 2 = score NULL.
+    fn table_with_nulls() -> DataTable {
+        let mut table = DataTable::new("t");
+        table.add_column(DataColumn::new("id"));
+        table.add_column(DataColumn::new("score"));
+        table.add_column(DataColumn::new("label"));
+
+        table
+            .add_row(DataRow::new(vec![
+                DataValue::Integer(1),
+                DataValue::Integer(50),
+                DataValue::String("alpha".to_string()),
+            ]))
+            .unwrap();
+        table
+            .add_row(DataRow::new(vec![
+                DataValue::Integer(2),
+                DataValue::Integer(30),
+                DataValue::String("beta".to_string()),
+            ]))
+            .unwrap();
+        table
+            .add_row(DataRow::new(vec![
+                DataValue::Integer(3),
+                DataValue::Null,
+                DataValue::Null,
+            ]))
+            .unwrap();
+
+        table
+    }
+
+    /// Evaluate a WHERE clause against one row and return its truth value.
+    fn eval(table: &DataTable, predicate: &str, row: usize) -> Trilean {
+        let sql = format!("SELECT * FROM t WHERE {predicate}");
+        let mut parser = Parser::new(&sql);
+        let statement = parser.parse().expect("failed to parse");
+        let where_clause = statement.where_clause.expect("expected a WHERE clause");
+
+        let mut evaluator = RecursiveWhereEvaluator::new(table);
+        evaluator
+            .evaluate(&where_clause, row)
+            .expect("evaluation failed")
+    }
+
+    // --- P18: `= NULL` yields UNKNOWN, never a match ---
+
+    #[test]
+    fn equals_null_is_unknown_for_every_row() {
+        let t = table_with_nulls();
+        // Including the NULL row itself: `NULL = NULL` is UNKNOWN, not TRUE.
+        // Returning TRUE here is exactly what made `WHERE score = NULL` behave
+        // like `IS NULL`.
+        for row in 0..3 {
+            assert_eq!(eval(&t, "score = NULL", row), Trilean::Unknown, "row {row}");
+        }
+    }
+
+    #[test]
+    fn comparison_against_a_null_column_is_unknown() {
+        let t = table_with_nulls();
+        assert_eq!(eval(&t, "score = 50", 2), Trilean::Unknown);
+        assert_eq!(eval(&t, "score > 10", 2), Trilean::Unknown);
+        assert_eq!(eval(&t, "score <> 50", 2), Trilean::Unknown);
+    }
+
+    #[test]
+    fn is_null_stays_two_valued() {
+        // The sanctioned way to match a NULL must keep working — that is what
+        // makes losing `= NULL` costless.
+        let t = table_with_nulls();
+        assert_eq!(eval(&t, "score IS NULL", 2), Trilean::True);
+        assert_eq!(eval(&t, "score IS NULL", 0), Trilean::False);
+        assert_eq!(eval(&t, "score IS NOT NULL", 0), Trilean::True);
+        assert_eq!(eval(&t, "score IS NOT NULL", 2), Trilean::False);
+    }
+
+    #[test]
+    fn in_list_with_a_null_matches_only_real_equals() {
+        let t = table_with_nulls();
+        // A match still wins outright, even with a NULL in the list.
+        assert_eq!(eval(&t, "score IN (50, NULL)", 0), Trilean::True);
+        // No match, but a NULL was compared: UNKNOWN, not FALSE. Returning
+        // FALSE here is invisible under IN and wrong under NOT IN.
+        assert_eq!(eval(&t, "score IN (50, NULL)", 1), Trilean::Unknown);
+        // NULL column against a list with no NULL in it: also UNKNOWN.
+        assert_eq!(eval(&t, "score IN (50, 70)", 2), Trilean::Unknown);
+        // Nothing NULL anywhere: ordinary FALSE.
+        assert_eq!(eval(&t, "score IN (50, 70)", 1), Trilean::False);
+    }
+
+    // --- P19: NOT must not turn UNKNOWN into TRUE ---
+
+    #[test]
+    fn not_in_excludes_nulls() {
+        let t = table_with_nulls();
+        // The bug: UNKNOWN collapsed to false and `!false` admitted the row.
+        assert_eq!(eval(&t, "score NOT IN (50, 70)", 2), Trilean::Unknown);
+        assert_eq!(eval(&t, "score NOT IN (50, 70)", 0), Trilean::False);
+        assert_eq!(eval(&t, "score NOT IN (50, 70)", 1), Trilean::True);
+    }
+
+    #[test]
+    fn not_over_an_unknown_comparison_stays_unknown() {
+        let t = table_with_nulls();
+        assert_eq!(eval(&t, "NOT (score > 50)", 2), Trilean::Unknown);
+        assert_eq!(eval(&t, "NOT (score > 50)", 1), Trilean::True);
+    }
+
+    // --- The truth tables, exercised through real predicates ---
+
+    /// CONTROL — passes with and without the P18/P19 fix, because the old
+    /// bool evaluator also produced FALSE here (for the wrong reason: it
+    /// collapsed the UNKNOWN rather than letting FALSE dominate). Kept because
+    /// it pins the half of AND's truth table the fix must not disturb; do not
+    /// read a pass here as evidence the fix works.
+    #[test]
+    fn false_still_dominates_and_over_unknown() {
+        let t = table_with_nulls();
+        // Row 1 has score 30, so `score = 50` is FALSE. FALSE AND UNKNOWN is
+        // FALSE — the row is excluded for a definite reason, not an unknown
+        // one. Getting this wrong would make the NOT of it wrong too.
+        assert_eq!(eval(&t, "score = 50 AND label = NULL", 1), Trilean::False);
+        assert_eq!(
+            eval(&t, "NOT (score = 50 AND label = NULL)", 1),
+            Trilean::True
+        );
+    }
+
+    #[test]
+    fn true_still_dominates_or_over_unknown() {
+        let t = table_with_nulls();
+        assert_eq!(eval(&t, "score = 50 OR label = NULL", 0), Trilean::True);
+        // Neither side definite: UNKNOWN.
+        assert_eq!(eval(&t, "score = 99 OR label = NULL", 1), Trilean::Unknown);
+    }
+
+    #[test]
+    fn between_follows_ands_truth_table() {
+        let t = table_with_nulls();
+        assert_eq!(eval(&t, "score BETWEEN 40 AND 60", 0), Trilean::True);
+        assert_eq!(eval(&t, "score BETWEEN 40 AND 60", 1), Trilean::False);
+        // NULL operand: UNKNOWN, and so is its negation.
+        assert_eq!(eval(&t, "score BETWEEN 40 AND 60", 2), Trilean::Unknown);
+        assert_eq!(
+            eval(&t, "NOT (score BETWEEN 40 AND 60)", 2),
+            Trilean::Unknown
+        );
+        // Row 1 is 30, below the lower bound, so the answer is FALSE outright
+        // even though the upper bound is NULL and that comparison is UNKNOWN.
+        assert_eq!(eval(&t, "score BETWEEN 40 AND NULL", 1), Trilean::False);
+    }
+
+    #[test]
+    fn like_against_a_null_is_unknown() {
+        let t = table_with_nulls();
+        assert_eq!(eval(&t, "label LIKE 'a%'", 0), Trilean::True);
+        assert_eq!(eval(&t, "label LIKE 'a%'", 1), Trilean::False);
+        assert_eq!(eval(&t, "label LIKE 'a%'", 2), Trilean::Unknown);
+        assert_eq!(eval(&t, "NOT (label LIKE 'a%')", 2), Trilean::Unknown);
+    }
+
+    // --- Controls: ordinary predicates over non-NULL data are untouched ---
+
+    #[test]
+    fn control_non_null_predicates_are_unchanged() {
+        let t = table_with_nulls();
+        assert_eq!(eval(&t, "score = 50", 0), Trilean::True);
+        assert_eq!(eval(&t, "score = 50", 1), Trilean::False);
+        assert_eq!(eval(&t, "score > 40 AND label = 'alpha'", 0), Trilean::True);
+        assert_eq!(eval(&t, "score > 40 OR label = 'beta'", 1), Trilean::True);
+        assert_eq!(eval(&t, "NOT (score = 50)", 1), Trilean::True);
+    }
 }

--- a/tests/comparison/corpus/02_where.toml
+++ b/tests/comparison/corpus/02_where.toml
@@ -97,7 +97,6 @@ sql = "SELECT id FROM null_edges WHERE score IN (50, 70) AND team = 'alpha' ORDE
 id = "in_subquery_then_and"
 data = "null_edges.csv"
 sql = "SELECT id FROM null_edges WHERE score IN (SELECT score FROM null_edges WHERE id < 5) AND team = 'alpha' ORDER BY id"
-expect = "DIFFER"
 # P29, the subquery form — pinned separately because the IN-list and IN-subquery
 # paths are built differently (see P11) and a fix to one need not reach the other.
 # In the event the P29/P30 precedence fix covered both, since they share
@@ -143,11 +142,11 @@ sql = "SELECT id, team, score FROM null_edges WHERE team = 'beta' OR score IN (5
 id = "in_list_with_null_literal"
 data = "null_edges.csv"
 sql = "SELECT id FROM null_edges WHERE score IN (50, NULL) ORDER BY id"
-expect = "DIFFER"
-# P18, found 2026-08-08 while fixing P29/P30 — the literal-list form that
-# isolates what in_subquery_then_and trips over, with no subquery involved.
-# A NULL in the list matches every NULL-scored row: we return ids 1,2,3,10,11,12
-# where DuckDB returns 1,2. IN is built on the same equality as `= NULL`.
+# P18, found 2026-08-08 while fixing P29/P30, FIXED 2026-08-22 — the literal-list
+# form that isolates what in_subquery_then_and trips over, with no subquery
+# involved. A NULL in the list used to match every NULL-scored row: we returned
+# ids 1,2,3,10,11,12 where DuckDB returns 1,2. IN is built on the same equality
+# as `= NULL`, which is why one fix closed both.
 #
 # Discriminating pair: where_in_with_null_col (tier 10) AGREEs — a NULL column
 # value against a list with NO NULL in it is excluded correctly. The variable
@@ -160,3 +159,22 @@ sql = "SELECT id, team, score FROM null_edges WHERE team = 'alpha' AND score IN 
 # Added with the P29/P30 fix. IN in the MIDDLE of a chain — the case that needs
 # parse_comparison to both consume the IN and hand control back to the AND loop.
 # The old top-level placement could not express this at all.
+
+# --- P32: NOT LIKE does not parse ---
+
+[[case]]
+id = "not_like_pattern"
+data = "null_edges.csv"
+sql = "SELECT id FROM null_edges WHERE label NOT LIKE 'a%' ORDER BY id"
+expect = "GAP"
+# P32, found 2026-08-22 while verifying the P18/P19 fix against DuckDB. `NOT`
+# only accepts `IN` after it, so this is a parse error: "Expected IN after NOT".
+# Pre-existing — confirmed against main, unrelated to the three-valued-logic
+# work — and pinned here rather than fixed in that change, per the standing
+# rule that a divergence found while fixing something else gets its own entry.
+#
+# Worth having as a case regardless of the parse gap: DuckDB returns ids
+# 1,3,4,7,8,9 — note it EXCLUDES the NULL-label rows (2,5,10,11,12), which is
+# the same UNKNOWN-under-NOT rule as P19. So when the parse gap is closed, this
+# doubles as coverage that NOT LIKE inherits the fixed NULL semantics; the
+# evaluator side is already implemented and returns UNKNOWN for a NULL operand.

--- a/tests/comparison/corpus/10_aggregate_nulls.toml
+++ b/tests/comparison/corpus/10_aggregate_nulls.toml
@@ -120,11 +120,15 @@ sql = "SELECT id, COALESCE(score, -1) AS c FROM null_edges ORDER BY id"
 id = "where_equals_null"
 data = "null_edges.csv"
 sql = "SELECT id FROM null_edges WHERE score = NULL"
-expect = "DIFFER"
-# P18. We return the four NULL-score rows — `= NULL` is being treated as
-# `IS NULL`. Under SQL three-valued logic `x = NULL` is UNKNOWN for every row
-# including NULL ones, so the correct answer is zero rows. `IS NULL` (above)
-# is the only way to match a NULL and it already works.
+# P18, FIXED 2026-08-22. We used to return the four NULL-score rows — `= NULL`
+# was being treated as `IS NULL`. Under SQL three-valued logic `x = NULL` is
+# UNKNOWN for every row including NULL ones, so the correct answer is zero rows.
+# `IS NULL` (above) is the only way to match a NULL and it already worked.
+#
+# Root cause was one line in `compare_values`: `(Null, Null) => Some(Equal)`.
+# That is *correct* for ORDER BY, which needs NULLs to group together, and the
+# WHERE evaluator was reusing the same answer. The fix tests for NULL at the
+# predicate layer instead of changing the shared comparator.
 
 # --- P19: NOT IN does not exclude NULLs ---
 
@@ -132,11 +136,15 @@ expect = "DIFFER"
 id = "where_not_in_excludes_null"
 data = "null_edges.csv"
 sql = "SELECT id FROM null_edges WHERE score NOT IN (50, 70) ORDER BY id"
-expect = "DIFFER"
-# P19. We return 8 rows, including the NULL-score rows; DuckDB returns 4.
-# `NULL NOT IN (50, 70)` is UNKNOWN, not TRUE, so those rows must not pass.
-# Note `where_not_equal_excludes_null` above gets the equivalent case right,
-# so this is an inconsistency inside our own NULL handling.
+# P19, FIXED 2026-08-22. We used to return 8 rows, including the NULL-score
+# rows; DuckDB returns 4. `NULL NOT IN (50, 70)` is UNKNOWN, not TRUE, so those
+# rows must not pass. `where_not_equal_excludes_null` above already got the
+# equivalent case right, which is what marked this as an inconsistency inside
+# our own NULL handling rather than a considered rule.
+#
+# The fix is in `evaluate_in_list`: IN is `x = a OR x = b OR ...`, so when
+# nothing matches but some comparison was UNKNOWN, the answer is UNKNOWN, not
+# FALSE. Under NOT that difference is the entire bug — FALSE negates to TRUE.
 
 # --- P20: `||` treats NULL as an empty string ---
 


### PR DESCRIPTION
Closes [P18](../blob/main/docs/SQL_PARITY.md#p18) and [P19](../blob/main/docs/SQL_PARITY.md#p19) — the final slice of [R10](../blob/main/docs/ENGINE_REFACTORING.md#r10). **Parity 125 → 129 AGREE**, four corpus cases flipping DIFFER → AGREE with nothing regressing.

## What changes for users

```sql
WHERE score = NULL           -- returned the NULL rows; now returns none
WHERE score IN (50, NULL)    -- matched every NULL row; now matches only the 50s
WHERE score NOT IN (50, 70)  -- returned 8 rows; now returns 4
```

`IS NULL` / `IS NOT NULL` are unchanged and remain the way to match a NULL — which is what makes losing `= NULL` costless.

## Root cause: a correct line, reused in the wrong place

`compare_values` reports `(Null, Null) => Some(Ordering::Equal)`. That is **not a bug** — `ORDER BY` needs NULLs to group together when sorting. The WHERE evaluator was reusing the same answer, and that is precisely why `= NULL` behaved like `IS NULL`.

So the fix tests for NULL **at the predicate layer**, in a new `compare_trilean` helper, and leaves the shared comparator alone. Pushing it down into `compare_with_op` would have fixed the predicate and broken sorting — `compare_values` has four callers including `datatable_view`.

Applied at the comparison arm, inside `evaluate_in_list`, to `BETWEEN`'s two bounds, to `LIKE`, and to the arithmetic evaluator's NULL result.

**`IN` needed the only real logic.** It is `x = a OR x = b OR ...`, so it inherits OR's truth table: a TRUE anywhere wins outright, but if nothing matched and any comparison was UNKNOWN, the answer is UNKNOWN — not FALSE. That distinction is *invisible* under `IN` (both drop the row) and is the entire bug under `NOT IN`, where FALSE wrongly negates to TRUE.

## Why this diff is small

Slices 1a (the `Trilean` type) and 1b (the evaluator conversion) shipped first as provable no-ops, so the semantic change here is **~40 lines** rather than buried in 200 lines of signature churn. 1b was 187 changed lines with zero behaviour change; this is 40 with all of it. The acceptance criteria differed in kind too — 1b had to leave parity *exactly* unmoved, this had to move exactly the four pinned cases and nothing else. Both held.

## Tests

11 env-free regression tests that assert the **`Trilean` directly, not row counts**. That matters: UNKNOWN and FALSE are indistinguishable by row count under `WHERE` (both drop the row) and only diverge under `NOT`, so a row-counting test would have passed against the broken evaluator for half of these cases.

**Verified 8 of the 11 fail without the fix** (reverted the evaluator, kept the tests, re-ran). The 3 that pass either way are labelled as controls in the source, including one that is explicitly annotated *"do not read a pass here as evidence the fix works"*.

## New finding pinned, not fixed

**[P32](../blob/main/docs/SQL_PARITY.md#p32) — `NOT LIKE` does not parse** (`Expected IN after NOT`). Found while verifying against DuckDB; **pre-existing**, confirmed against `main`, unrelated to this work. Recorded as a corpus GAP per the standing rule that a divergence found while fixing something else gets its own entry. Its evaluator half is already done here — `LIKE` returns UNKNOWN for a NULL operand — so closing it is a parser change alone.

## Verification

- **Parity contract holds: 129 AGREE / 17 DIFFER / 13 GAP / 1 BOTH_ERR of 160 cases**
- `cargo test` — **721 passed, 0 failed**
- All FORMAL examples pass — **no expectation churn**, since none of them exercise NULL predicates, so the P21 re-capture trap did not bite this time
- Python suite: same 6 environmental failures as `main` (verified by stash-and-compare)
- `cargo clippy --lib` unchanged at 365 warnings; `cargo fmt --check` clean

## Note for the next version bump

This is the first parity fix that changes results a user could notice. The CHANGELOG is maintained at bump time rather than per-PR here, so it is not touched — but `= NULL` and `NOT IN` deserve a line when the version next moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
